### PR TITLE
Document ROCm 1.9 Debug Agent and ROCm DBG

### DIFF
--- a/ROCm_Tools/ROCm-Tools.rst
+++ b/ROCm_Tools/ROCm-Tools.rst
@@ -514,8 +514,8 @@ state of the GPU to ``stdout``. Possible error states include:
 -  The GPU executes an ``S_TRAP`` instruction. The ``__builtin_trap()``
    language builtin can be used to generate a ``S_TRAP``.
 -  A SIGINT (``ctrl c``) or SIGTERM (``kill -15``) signal is sent to the
-   application while executing GPU code. Enabled if environment variable
-   ``ROCM_DEBUG_ENABLE_LINUX_SIGNALS=0``.
+   application while executing GPU code. Enabled by the
+   ``ROCM_DEBUG_ENABLE_LINUX_SIGNALS`` environment variable.
 
 For example, a sample print out for GPU memory fault is:
 

--- a/ROCm_Tools/ROCm-Tools.rst
+++ b/ROCm_Tools/ROCm-Tools.rst
@@ -495,9 +495,9 @@ different version set the LD_LIBRARY_PATH, for example:
    export LD_LIBRARY_PATH=/path_to_directory_containing_librocr_debug_agent64.so
 
 To display the machine code instructions of wavefronts, together with
-the source text location, the ROCr Debug Agent using the llvm-objdump
+the source text location, the ROCr Debug Agent uses the llvm-objdump
 tool. Ensure that a version that supports AMD GCN GPUs is on your
-’$PATH`. For example, for the ROCm1.9:
+’$PATH`. For example, for ROCm 1.9:
 
 .. code:: sh
 

--- a/ROCm_Tools/ROCm-Tools.rst
+++ b/ROCm_Tools/ROCm-Tools.rst
@@ -614,11 +614,12 @@ To save to a file use:
 This will create a file called ``ROCm_Wave_State_Dump`` in code object
 directory (see below).
 
-To return to the default ``stdout`` use:
+To return to the default ``stdout`` use either of the following:
 
 .. code:: sh
 
    export ROCM_DEBUG_WAVE_STATE_DUMP=stdout
+   unset ROCM_DEBUG_WAVE_STATE_DUMP
 
 Linux Signal Control
 --------------------
@@ -631,11 +632,12 @@ sent to the application:
 
    export ROCM_DEBUG_ENABLE_LINUX_SIGNALS=1
 
-The following will disable this behavior:
+Either of the following will disable this behavior:
 
 .. code:: sh
 
    export ROCM_DEBUG_ENABLE_LINUX_SIGNALS=0
+   unset ROCM_DEBUG_ENABLE_LINUX_SIGNALS
 
 Code Object Saving
 ------------------
@@ -664,10 +666,16 @@ application exits normally. If a code object directory path is specified
 then neither the saved code objects, nor the code object directory will
 be deleted.
 
+To return to using the default code object directory use:
+
+.. code:: sh
+
+   unset ROCM_DEBUG_SAVE_CODE_OBJECT
+
 Logging
 -------
 
-By default ROCr Debug Aget logging is disabled. It can be enabled to
+By default ROCr Debug Agent logging is disabled. It can be enabled to
 display to ``stdout`` using:
 
 .. code:: sh
@@ -681,6 +689,12 @@ Or to a file using:
    export ROCM_DEBUG_ENABLE_AGENTLOG=<filename>
 
 Which will write to the file ``<filename>_AgentLog_PID_XXXX.log``.
+
+To disable logging use:
+
+.. code:: sh
+
+   unset ROCM_DEBUG_ENABLE_AGENTLOG
 
 ROCm-GDB
 =========


### PR DESCRIPTION
- Add documentation for ROCr Debug Agent.
- Remove documentation for ROCm DGB which is being revised to use ROCr Debug Agent in an upcoming release.