### PR TITLE
Add notice about C++AMP being removed from 2.0. Use canonical rst.

### DIFF
--- a/Current_Release_Notes/Current-Release-Notes.rst
+++ b/Current_Release_Notes/Current-Release-Notes.rst
@@ -5,6 +5,14 @@
 Current Release Notes
 =====================
 
+New features and enhancements in ROCm 2.0 (*Work In Progress*)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Removed features
+^^^^^^^^^^^^^^^^
+
+- HCC: removed support for C++AMP
+
 New features and enhancements in ROCm 1.9.2
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -30,11 +38,11 @@ New features and enhancements in ROCm 1.9.1
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Added DPM support to Vega 7nm
-^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Dynamic Power Management feature is enabled on Vega 7nm.
- 
-Fix for 'ROCm profiling' that used to fail with a "Version mismatch between HSA runtime and libhsa-runtime-tools64.so.1" error
-^^^^^^^^^^^^^^^^^^^^
+
+Fix for 'ROCm profiling' "Version mismatch between HSA runtime and libhsa-runtime-tools64.so.1" error
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 New features and enhancements in ROCm 1.9.0
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -103,6 +111,6 @@ To try ROCm with an upstream kernel, install ROCm as normal, but do not
 install the rock-dkms package. Also add a udev rule to control /dev/kfd
 permissions:
 
-::
+.. code:: sh
 
     echo 'SUBSYSTEM=="kfd", KERNEL=="kfd", TAG+="uaccess", GROUP="video"' | sudo tee /etc/udev/rules.d/70-kfd.rules

--- a/Installation_Guide/HCC-Compiler.rst
+++ b/Installation_Guide/HCC-Compiler.rst
@@ -16,9 +16,11 @@ Download HCC
 The project now employs git submodules to manage external components it depends upon. It it advised to add --recursive when you clone the project so all submodules are fetched automatically.
 
 For example:
-::
- # automatically fetches all submodules
- git clone --recursive -b clang_tot_upgrade https://github.com/RadeonOpenCompute/hcc.git
+
+.. code:: sh
+
+    # automatically fetches all submodules
+    git clone --recursive -b clang_tot_upgrade https://github.com/RadeonOpenCompute/hcc.git
 
 For more information about git submodules, please refer to `git documentation <https://git-scm.com/book/en/v2/Git-Tools-Submodules>`_.
 
@@ -26,37 +28,53 @@ Build HCC from source
 ########################
 
 To configure and build HCC from source, use the following steps:
-::
- mkdir -p build; cd build
- cmake -DCMAKE_BUILD_TYPE=Release ..
- make
+
+.. code:: sh
+
+    mkdir -p build; cd build
+    cmake -DCMAKE_BUILD_TYPE=Release ..
+    make
 
 To install it, use the following steps:
-::
- sudo make install
+
+.. code:: sh
+
+    sudo make install
 
 Use HCC
 ##########
 
 For C++AMP source codes:
-::
- hcc `clamp-config --cxxflags --ldflags` foo.cpp
+
+.. code:: sh
+
+    hcc `clamp-config --cxxflags --ldflags` foo.cpp
+
+**WARNING: From ROCm version 2.0 onwards C++AMP is no longer available in HCC.**
 
 For HC source codes:
-::
- hcc `hcc-config --cxxflags --ldflags` foo.cpp
+
+.. code:: sh
+
+    hcc `hcc-config --cxxflags --ldflags` foo.cpp
 
 In case you build HCC from source and want to use the compiled binaries directly in the build directory:
 
 For C++AMP source codes:
-::
- # notice the --build flag
- bin/hcc `bin/clamp-config --build --cxxflags --ldflags` foo.cpp
+
+.. code:: sh
+
+    # notice the --build flag
+    bin/hcc `bin/clamp-config --build --cxxflags --ldflags` foo.cpp
+
+**WARNING: From ROCm version 2.0 onwards C++AMP is no longer available in HCC.**
 
 For HC source codes:
-::
- # notice the --build flag
- bin/hcc `bin/hcc-config --build --cxxflags --ldflags` foo.cpp
+
+.. code:: sh
+
+    # notice the --build flag
+    bin/hcc `bin/hcc-config --build --cxxflags --ldflags` foo.cpp
 
 Multiple ISA
 #################
@@ -66,26 +84,30 @@ use --amdgpu-target= command line option
 *******************************************
 
 It's possible to specify multiple **--amdgpu-target=**  option. Example:
-::
- # ISA for Hawaii(gfx701), Carrizo(gfx801), Tonga(gfx802) and Fiji(gfx803) would 
- # be produced
- hcc `hcc-config --cxxflags --ldflags` \
-    --amdgpu-target=gfx701 \
-    --amdgpu-target=gfx801 \
-    --amdgpu-target=gfx802 \
-    --amdgpu-target=gfx803 \
-    foo.cpp
+
+.. code:: sh
+
+    # ISA for Hawaii(gfx701), Carrizo(gfx801), Tonga(gfx802) and Fiji(gfx803) would
+    # be produced
+    hcc `hcc-config --cxxflags --ldflags` \
+        --amdgpu-target=gfx701 \
+        --amdgpu-target=gfx801 \
+        --amdgpu-target=gfx802 \
+        --amdgpu-target=gfx803 \
+        foo.cpp
 
 
 use HCC_AMDGPU_TARGET env var
 ********************************
 
 Use , to delimit each AMDGPU target in HCC. Example:
-::
- export HCC_AMDGPU_TARGET=gfx701,gfx801,gfx802,gfx803
- # ISA for Hawaii(gfx701), Carrizo(gfx801), Tonga(gfx802) and Fiji(gfx803) would 
- # be produced
- hcc `hcc-config --cxxflags --ldflags` foo.cpp
+
+.. code:: sh
+
+    export HCC_AMDGPU_TARGET=gfx701,gfx801,gfx802,gfx803
+    # ISA for Hawaii(gfx701), Carrizo(gfx801), Tonga(gfx802) and Fiji(gfx803) would
+    # be produced
+    hcc `hcc-config --cxxflags --ldflags` foo.cpp
 
 
 configure HCC use CMake HSA_AMDGPU_GPU_TARGET variable
@@ -94,14 +116,16 @@ configure HCC use CMake HSA_AMDGPU_GPU_TARGET variable
 If you build HCC from source, it's possible to configure it to automatically produce multiple ISAs via HSA_AMDGPU_GPU_TARGET CMake variable.
 
 Use ; to delimit each AMDGPU target. Example:
-::
- # ISA for Hawaii(gfx701), Carrizo(gfx801), Tonga(gfx802) and Fiji(gfx803) would 
- # be produced by default
- cmake \
-     -DCMAKE_BUILD_TYPE=Release \
-     -DROCM_DEVICE_LIB_DIR=~hcc/ROCm-Device-Libs/build/dist/lib \
-     -DHSA_AMDGPU_GPU_TARGET="gfx701;gfx801;gfx802;gfx803" \
-     ../hcc
+
+.. code:: sh
+
+    # ISA for Hawaii(gfx701), Carrizo(gfx801), Tonga(gfx802) and Fiji(gfx803) would
+    # be produced by default
+    cmake \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DROCM_DEVICE_LIB_DIR=~hcc/ROCm-Device-Libs/build/dist/lib \
+        -DHSA_AMDGPU_GPU_TARGET="gfx701;gfx801;gfx802;gfx803" \
+        ../hcc
 
 
 CodeXL Activity Logger
@@ -110,18 +134,22 @@ CodeXL Activity Logger
 To enable the `CodeXL Activity Logger <https://github.com/RadeonOpenCompute/ROCm-Profiler/tree/master/CXLActivityLogger>`_, use the USE_CODEXL_ACTIVITY_LOGGER environment variable.
 
 Configure the build in the following way:
-::
- cmake \
-     -DCMAKE_BUILD_TYPE=Release \
-     -DHSA_AMDGPU_GPU_TARGET=<AMD GPU ISA version string> \
-     -DROCM_DEVICE_LIB_DIR=<location of the ROCm-Device-Libs bitcode> \
-     -DUSE_CODEXL_ACTIVITY_LOGGER=1 \
-     <ToT HCC checkout directory>
+
+.. code:: sh
+
+    cmake \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DHSA_AMDGPU_GPU_TARGET=<AMD GPU ISA version string> \
+        -DROCM_DEVICE_LIB_DIR=<location of the ROCm-Device-Libs bitcode> \
+        -DUSE_CODEXL_ACTIVITY_LOGGER=1 \
+        <ToT HCC checkout directory>
 
 
 In your application compiled using hcc, include the CodeXL Activity Logger header:
-::
- #include <CXLActivityLogger.h>
+
+.. code:: cpp
+
+    #include <CXLActivityLogger.h>
 
 
 For information about the usage of the Activity Logger for profiling, please refer to its `documentation <https://github.com/RadeonOpenCompute/ROCm-Profiler/blob/master/CXLActivityLogger/doc/AMDTActivityLogger.pdf>`_.
@@ -132,8 +160,10 @@ HCC with ThinLTO Linking
 To enable the ThinLTO link time, use the KMTHINLTO environment variable.
 
 Set up your environment in the following way:
-::
- export KMTHINLTO=1
+
+.. code:: sh
+
+    export KMTHINLTO=1
 
 ThinLTO Phase 1 - Implemented
 ********************************

--- a/Programming_Guides/LanguageInto.rst
+++ b/Programming_Guides/LanguageInto.rst
@@ -193,5 +193,4 @@ Notes
 1. For HC and C++AMP, assume a captured _tiled_ext_ named "t_ext" and captured _extent_ named "ext".  These languages use captured variables to pass information to the kernel rather than using special built-in functions so the exact variable name may vary.
 2. The indexing functions (starting with ``thread-index``) show the terminology for a 1D grid.  Some APIs use reverse order of xyz / 012 indexing for 3D grids.
 3. HC allows tile dimensions to be specified at runtime while C++AMP requires that tile dimensions be specified at compile-time.  Thus hc syntax for tile dims is ``t_ext.tile_dim[0]`` while C++AMP is t_ext.tile_dim0.
-
-
+4. **From ROCm version 2.0 onwards C++AMP is no longer available in HCC.**

--- a/Programming_Guides/Programming-Guides.rst
+++ b/Programming_Guides/Programming-Guides.rst
@@ -73,7 +73,7 @@ What is Anaconda ?  It’s a modern open-source analytics platform powered by Py
 ROCm-enabled discrete GPUs via Numba. It gives superpowers to the people who are changing the world.
 
 Numba
-####### 
+#######
 Numba gives you the power to speed up your applications with high-performance functions written directly in Python. Through a few
 annotations, you can just-in-time compile array-oriented and math-heavy Python code to native machine instructions---offering
 performance similar to that of C, C++ and Fortran---without having to switch languages or Python interpreters.
@@ -199,11 +199,11 @@ Notes
 1. For HC and C++AMP, assume a captured _tiled_ext_ named "t_ext" and captured _extent_ named "ext".  These languages use captured variables to pass information to the kernel rather than using special built-in functions so the exact variable name may vary.
 2. The indexing functions (starting with `thread-index`) show the terminology for a 1D grid.  Some APIs use reverse order of xyz / 012 indexing for 3D grids.
 3. HC allows tile dimensions to be specified at runtime while C++AMP requires that tile dimensions be specified at compile-time.  Thus hc syntax for tile dims is ``t_ext.tile_dim[0]``  while C++AMP is ``t_ext.tile_dim0``.
-
+4. **From ROCm version 2.0 onwards C++AMP is no longer available in HCC.**
 
 
 HC Programming Guide
-===================
+====================
 
 **What is the Heterogeneous Compute (HC) API ?**
 
@@ -213,7 +213,7 @@ The Heterogeneous Compute Compiler (HCC) provides two important benefits:
 
 Ease of development
 
- 
+
    * A full C++ API for managing devices, queues and events
    * C++ data containers that provide type safety, multidimensional-array indexing and automatic data management
    * C++ kernel-launch syntax using parallel_for_each plus C++11 lambda functions
@@ -278,90 +278,118 @@ Download HCC
 ################
  The project now employs git submodules to manage external components it depends upon. It it advised to add --recursive when you clone the project so all submodules are fetched automatically.
 
-For example::
-  
+For example
+
+.. code:: sh
+
   # automatically fetches all submodules
   git clone --recursive -b clang_tot_upgrade https://github.com/RadeonOpenCompute/hcc.git
 
 Build HCC from source
 ######################
 
-First, install the build dependencies::
+First, install the build dependencies
+
+.. code:: sh
 
   # Ubuntu 14.04
   sudo apt-get install git cmake make g++  g++-multilib gcc-multilib libc++-dev libc++1 libc++abi-dev libc++abi1 python findutils libelf1 libpci3 file debianutils libunwind8-dev hsa-rocr-dev hsa-ext-rocr-dev hsakmt-roct-dev pkg-config rocm-utils
 
-::  
+.. code:: sh
 
   # Ubuntu 16.04
   sudo apt-get install git cmake make g++  g++-multilib gcc-multilib python findutils libelf1 libpci3 file debianutils libunwind- dev hsa-rocr-dev hsa-ext-rocr-dev hsakmt-roct-dev pkg-config rocm-utils
 
-::
+.. code:: sh
 
    # Fedora 23/24
    sudo dnf install git cmake make gcc-c++ python findutils elfutils-libelf pciutils-libs file pth rpm-build libunwind-devel hsa- rocr- dev hsa-ext-rocr-dev hsakmt-roct-dev pkgconfig rocm-utils
 
-Clone the HCC source tree::
+Clone the HCC source tree
+
+.. code:: sh
 
   # automatically fetches all submodules
   git clone --recursive -b clang_tot_upgrade https://github.com/RadeonOpenCompute/hcc.git
 
-Create a build directory and run cmake in that directory to configure the build::
+Create a build directory and run cmake in that directory to configure the build
+
+.. code:: sh
 
   mkdir build;
   cd build;
   cmake ../hcc
 
-Compile HCC::
+Compile HCC
+
+.. code:: sh
 
   make -j
 
-Run the unit tests:: 
+Run the unit tests
+
+.. code:: sh
 
   make test
 
 Create an installer package (DEB or RPM file)
 
-::
+.. code:: sh
 
   make package
 
 
 
-To configure and build HCC from source, use the following steps::
- 
+To configure and build HCC from source, use the following steps
+
+.. code:: sh
+
   mkdir -p build; cd build
   # NUM_BUILD_THREADS is optional
   # set the number to your CPU core numbers time 2 is recommended
-  # in this example we set it to 96 
+  # in this example we set it to 96
     cmake -DNUM_BUILD_THREADS=96 \
     -DCMAKE_BUILD_TYPE=Release \
   ..
   make
 
-To install it, use the following steps::
-  
+To install it, use the following steps
+
+.. code:: sh
+
   sudo make install
 
 Use HCC
 ########
 
-For C++AMP source codes::
+For C++AMP source codes
+
+.. code:: sh
 
   hcc `clamp-config --cxxflags --ldflags` foo.cpp
 
-For HC source codes::
- 
+**WARNING: From ROCm version 2.0 onwards C++AMP is no longer available in HCC.**
+
+For HC source codes
+
+.. code:: sh
+
  hcc `hcc-config --cxxflags --ldflags` foo.cpp
 
 In case you build HCC from source and want to use the compiled binaries directly in the build directory:
 
-For C++AMP source codes::
+For C++AMP source codes
+
+.. code:: sh
 
   # notice the --build flag
   bin/hcc `bin/clamp-config --build --cxxflags --ldflags` foo.cpp
 
-For HC source codes::
+**WARNING: From ROCm version 2.0 onwards C++AMP is no longer available in HCC.**
+
+For HC source codes
+
+.. code:: sh
 
   # notice the --build flag
   bin/hcc `bin/hcc-config --build --cxxflags --ldflags` foo.cpp
@@ -374,7 +402,7 @@ There exists an environment variable HCC_AMDGPU_TARGET to override the default G
 
 ============ ================== ==============================================================
 GCN Version   GPU/APU Family       Examples of Radeon GPU
-       
+
 ============ ================== ==============================================================
 gfx701        GFX7               FirePro W8100, FirePro W9100, Radeon R9 290, Radeon R9 390
 
@@ -385,17 +413,19 @@ gfx803        GFX8               R9 Fury, R9 Fury X, R9 Nano, FirePro S9300 x2, 
 
 gfx900        GFX9                 Vega10
 
-============ ================== ============================================================== 
+============ ================== ==============================================================
 
 Multiple ISA
 #############
 
 HCC now supports having multiple GCN ISAs in one executable file. You can do it in different ways: **use :: --amdgpu-target= command line option**
-It's possible to specify multiple --amdgpu-target= option. 
+It's possible to specify multiple --amdgpu-target= option.
 
-Example::
+Example
 
- # ISA for Hawaii(gfx701), Carrizo(gfx801), Tonga(gfx802) and Fiji(gfx803) would 
+.. code:: sh
+
+ # ISA for Hawaii(gfx701), Carrizo(gfx801), Tonga(gfx802) and Fiji(gfx803) would
  # be produced
  hcc `hcc-config --cxxflags --ldflags` \
     --amdgpu-target=gfx701 \
@@ -404,21 +434,25 @@ Example::
     --amdgpu-target=gfx803 \
     foo.cpp
 
-**use :: HCC_AMDGPU_TARGET env var** 
+**use :: HCC_AMDGPU_TARGET env var**
 
-Use, to delimit each AMDGPU target in HCC. Example::
-  
+Use, to delimit each AMDGPU target in HCC. Example
+
+.. code:: sh
+
   export HCC_AMDGPU_TARGET=gfx701,gfx801,gfx802,gfx803
-  # ISA for Hawaii(gfx701), Carrizo(gfx801), Tonga(gfx802) and Fiji(gfx803) would 
+  # ISA for Hawaii(gfx701), Carrizo(gfx801), Tonga(gfx802) and Fiji(gfx803) would
   # be produced
   hcc `hcc-config --cxxflags --ldflags` foo.cpp
 
 **configure HCC using the CMake HSA_AMDGPU_GPU_TARGET variable**
 
 If you build HCC from source, it's possible to configure it to automatically produce multiple ISAs via :: HSA_AMDGPU_GPU_TARGET CMake variable.
-Use ; to delimit each AMDGPU target. Example::
+Use ; to delimit each AMDGPU target. Example
 
- # ISA for Hawaii(gfx701), Carrizo(gfx801), Tonga(gfx802) and Fiji(gfx803) would 
+.. code:: sh
+
+ # ISA for Hawaii(gfx701), Carrizo(gfx801), Tonga(gfx802) and Fiji(gfx803) would
  # be produced by default
  cmake \
     -DCMAKE_BUILD_TYPE=Release \
@@ -431,7 +465,9 @@ CodeXL Activity Logger
 
 To enable the CodeXL Activity Logger, use the  USE_CODEXL_ACTIVITY_LOGGER environment variable.
 
-Configure the build in the following way::
+Configure the build in the following way
+
+.. code:: sh
 
   cmake \
     -DCMAKE_BUILD_TYPE=Release \
@@ -440,8 +476,10 @@ Configure the build in the following way::
     -DUSE_CODEXL_ACTIVITY_LOGGER=1 \
     <ToT HCC checkout directory>
 
-In your application compiled using hcc, include the CodeXL Activiy Logger header::
- 
+In your application compiled using hcc, include the CodeXL Activiy Logger header
+
+.. code:: cpp
+
   #include <CXLActivityLogger.h>
 
 For information about the usage of the Activity Logger for profiling, please refer to `documentation <https://documentation.help/CodeXL/amdtactivitylogger-library.htm>`_
@@ -458,56 +496,55 @@ HC comes with two header files as of now:
 
 Most HC APIs are stored under "hc" namespace, and the class name is the same as their counterpart in C++AMP "Concurrency" namespace. Users of C++AMP should find it easy to switch from C++AMP to HC.
 
-=============================== =======================
-C++AMP 		       			HC 
-=============================== =======================
-Concurrency::accelerator	 hc::accelerator
-Concurrency::accelerator_view	 hc::accelerator_view
-Concurrency::extent		 hc::extent
-Concurrency::index		 hc::index
-Concurrency::completion_future   hc::completion_future
-Concurrency::array		 hc::array
-Concurrency::array_view     	 hc::array_view
-
-=============================== ======================= 
+================================== =====================
+C++AMP 		       			             HC
+================================== =====================
+``Concurrency::accelerator``	     ``hc::accelerator``
+``Concurrency::accelerator_view``  ``hc::accelerator_view``
+``Concurrency::extent``		         ``hc::extent``
+``Concurrency::index``		         ``hc::index``
+``Concurrency::completion_future`` ``hc::completion_future``
+``Concurrency::array``		         ``hc::array``
+``Concurrency::array_view``     	 ``hc::array_view``
+================================== =====================
 
 
 HCC built-in macros
 #######################
 Built-in macros:
 
-==================== =======================================================================
-Macro                            Meaning 
-==================== =======================================================================
-__HCC__		      always be 1 
-__hcc_major__	      major version number of HCC 
-__hcc_minor__	      minor version number of HCC 
-__hcc_patchlevel__    patchlevel of HCC 
-__hcc_version__	      combined string of __hcc_major__, __hcc_minor__, __hcc_patchlevel__
-==================== =======================================================================
+====================== ===============================================================================
+Macro                  Meaning
+====================== ===============================================================================
+``__HCC__``		         always be 1
+``__hcc_major__``	     major version number of HCC
+``__hcc_minor__``	     minor version number of HCC
+``__hcc_patchlevel__`` patchlevel of HCC
+``__hcc_version__``	   combined string of ``__hcc_major__``, ``__hcc_minor__``, ``__hcc_patchlevel__``
+====================== ===============================================================================
 
-The rule for __hcc_patchlevel__ is: yyWW-(HCC driver git commit #)-(HCC clang git commit #)
+The rule for ``__hcc_patchlevel__`` is: yyWW-(HCC driver git commit #)-(HCC clang git commit #)
 
    * yy stands for the last 2 digits of the year
    * WW stands for the week number of the year
 
 Macros for language modes in use:
 
-=============== =========================================
- Macro           Meaning 
-=============== =========================================
-__KALMAR_AMP__    1 in case in C++ AMP mode (-std=c++amp) 
-__KALMAR_HC__     1 in case in HC mode (-hc) 
-=============== =========================================
+================== ==========================================================================
+ Macro             Meaning
+================== ==========================================================================
+``__KALMAR_AMP__`` 1 in case in C++ AMP mode (-std=c++amp; **Removed from ROCm 2.0 onwards**)
+``__KALMAR_HC__``  1 in case in HC mode (-hc)
+================== ==========================================================================
 
 Compilation mode: HCC is a single-source compiler where kernel codes and host codes can reside in the same file. Internally HCC would trigger 2 compilation iterations, and the following macros can be used by user programs to determine which mode the compiler is in.
 
-====================== =================================================================
-Macro           		Meaning 
-====================== =================================================================
-__KALMAR_ACCELERATOR_   not 0 in case the compiler runs in kernel code compilation mode
-__KALMAR_CPU__          not 0 in case the compiler runs in host code compilation mode
-====================== =================================================================
+========================== ===============================================================
+Macro           		       Meaning
+========================== ===============================================================
+``__KALMAR_ACCELERATOR__`` not 0 in case the compiler runs in kernel code compilation mode
+``__KALMAR_CPU__``         not 0 in case the compiler runs in host code compilation mode
+========================== ===============================================================
 
 HC-specific features
 ########################
@@ -530,13 +567,17 @@ HC supports the automatic synchronization behavior as in C++ AMP. In addition, H
 
 **Annotation of device functions**
 
-C++ AMP uses the restrict(amp) keyword to annotate functions that runs on the device. 
-::
+C++ AMP uses the restrict(amp) keyword to annotate functions that runs on the device.
+
+.. code:: cpp
+
  void foo() restrict(amp) { .. } ... parallel_for_each(...,[=] () restrict(amp) { foo(); });
 
-HC uses a function attribute ([[hc]] or __attribute__((hc)) ) to annotate a device function. 
-::
-  void foo() [[hc]] { .. } ... parallel_for_each(...,[=] () [[hc]] { foo(); }); 
+HC uses a function attribute ([[hc]] or __attribute__((hc)) ) to annotate a device function.
+
+.. code:: cpp
+
+  void foo() [[hc]] { .. } ... parallel_for_each(...,[=] () [[hc]] { foo(); });
 
 The [[hc]] annotation for the kernel function called by parallel_for_each is optional as it is automatically annotated as a device function by the hcc compiler. The compiler also supports partial automatic [[hc]] annotation for functions that are called by other device functions within the same source file:
 
@@ -545,25 +586,25 @@ Since bar is called by foo, which is a device function, the hcc compiler will au
 
 **Dynamic tile size**
 
-C++ AMP doesn't support dynamic tile size. The size of each tile dimensions has to be a compile-time constant specified as template arguments to the tile_extent object: 
+C++ AMP doesn't support dynamic tile size. The size of each tile dimensions has to be a compile-time constant specified as template arguments to the tile_extent object:
 
- `extent<2> <http://scchan.github.io/hcc/classConcurrency_1_1extent.html>`_  ex(x, y) 
+ `extent<2> <http://scchan.github.io/hcc/classConcurrency_1_1extent.html>`_  ex(x, y)
 
  To create a tile extent of 8x8 from the extent object,note that the tile dimensions have to be constant values:
 
    tiled_extent<8,8> t_ex(ex)
 
-parallel_for_each(t_ex, [=](tiled_index<8,8> t_id) restrict(amp) { ... }); 
+parallel_for_each(t_ex, [=](tiled_index<8,8> t_id) restrict(amp) { ... });
 
-    HC supports both static and dynamic tile size: 
+    HC supports both static and dynamic tile size:
 
    `extent<2> <http://scchan.github.io/hcc/classConcurrency_1_1extent.html>`_ ex(x,y)
 
-To create a tile extent from dynamically calculated values,note that the the tiled_extent template takes the rank instead of dimensions 
+To create a tile extent from dynamically calculated values,note that the the tiled_extent template takes the rank instead of dimensions
 
-         tx = test_x ? tx_a : tx_b; 
+         tx = test_x ? tx_a : tx_b;
 
-         ty = test_y ? ty_a : ty_b; 
+         ty = test_y ? ty_a : ty_b;
 
          tiled_extent<2> t_ex(ex, tx, ty);
 
@@ -575,10 +616,10 @@ C++ AMP doesn't support lambda capture of memory pointer into a GPU kernel.
 
 HC supports capturing memory pointer by a GPU kernel.
 
-allocate GPU memory through the HSA API 
+allocate GPU memory through the HSA API
 ``int* gpu_pointer; hsa_memory_allocate(..., &gpu_pointer); ... parallel_for_each(ext, [=](index i) [[hc]] { gpu_pointer[i[0]]++; }``
 
-For HSA APUs that supports system wide shared virtual memory, a GPU kernel can directly access system memory allocated by the host: 
+For HSA APUs that supports system wide shared virtual memory, a GPU kernel can directly access system memory allocated by the host:
 ``int* cpu_memory = (int*) malloc(...); ... parallel_for_each(ext, [=](index i) [[hc]] { cpu_memory[i[0]]++; });``
 
 
@@ -600,10 +641,10 @@ Some other useful features:
 | HCC_PROFILE=1 shows a summary of kernel and data commands when hcc exits (under development).
 | HCC_PROFILE=2 enables a profile message after each command (kernel or data movement) completes.
 
-| Additionally, the HCC_PROFILE_VERBOSE variable controls the information shown in the profile log. This is a bit-vector: 
-| 0x2 : Show start and stop timestamps for each command. 
-| 0x4 : Show the device.queue.cmdseqnum for each command. 
-| 0x8 : Show the short CPU TID for each command (not supported).  
+| Additionally, the HCC_PROFILE_VERBOSE variable controls the information shown in the profile log. This is a bit-vector:
+| 0x2 : Show start and stop timestamps for each command.
+| 0x4 : Show the device.queue.cmdseqnum for each command.
+| 0x8 : Show the short CPU TID for each command (not supported).
 | 0x10 : Show logs for barrier commands.
 
 **Sample Output**
@@ -612,25 +653,29 @@ Some other useful features:
 Kernel Commands
 ++++++++++++++++
 
-This shows the simplest trace output for kernel commands with no additional verbosity flags::
- 
+This shows the simplest trace output for kernel commands with no additional verbosity flags
+
+.. code:: sh
+
  $ HCC_PROFILE=2 ./my-hcc-app ...
  profile:  kernel;            Im2Col;   17.8 us;
  profile:  kernel;  tg_betac_alphaab;   32.6 us;
  profile:  kernel;     MIOpenConvUni;  125.4 us;
 
-::
+.. code:: sh
 
   PROFILE:  TYPE;    KERNEL_NAME     ;  DURATION;
- 
-This example shows profiled kernel commands with full verbose output::
+
+This example shows profiled kernel commands with full verbose output
+
+.. code:: sh
 
  $ HCC_PROFILE=2 HCC_PROFILE_VERBOSE=0xf ./my-hcc-app ...
  profile:  kernel;            Im2Col;   17.8 us;  94859076277181; 94859076294941; #0.3.1;
  profile:  kernel;  tg_betac_alphaab;   32.6 us;  94859537593679; 94859537626319; #0.3.2;
  profile:  kernel;     MIOpenConvUni;  125.4 us;  94860077852212; 94860077977651; #0.3.3;
 
-::
+.. code:: sh
 
   PROFILE:  TYPE;    KERNEL_NAME     ;  DURATION;  START         ; STOP          ; ID
 
@@ -646,7 +691,8 @@ Memory Copy Commands
 +++++++++++++++++++++
 
 This example shows memory copy commands with full verbose output:
-::
+
+.. code:: sh
 
  profile: copyslo; HostToDevice_sync_slow;   909.2 us; 94858703102; 94858704012; #0.0.0; 2359296 bytes;  2.2 MB;   2.5 GB/s;
  profile:    copy; DeviceToHost_sync_fast;   117.0 us; 94858726408; 94858726525; #0.0.0; 1228800 bytes;  1.2 MB;   10.0 GB/s;
@@ -662,8 +708,8 @@ This example shows memory copy commands with full verbose output:
 	* Copy kind: HostToDevice, HostToHost, DeviceToHost, DeviceToDevice, or PeerToPeer. DeviceToDevice indicates the copy occurs on a single device while PeerToPeer indicates a copy between devices.
 	* Sync or Async. Synchronous copies indicate the host waits for the completion for the copy. Asynchronous copies are launched by the host without waiting for the copy to complete.
 	* Fast or Slow. Fast copies use the GPUs optimized copy routines from the hsa_amd_memory_copy routine. Slow copies typically involve unpinned host memory and can't take the fast path.
-	* For example `HostToDevice_async_fast.
-	
+	* For example `HostToDevice_async_fast`.
+
 * DURATION: command duration measured in us. This is measured using the GPU timestamps and represents the command execution on the accelerator device.
 * START: command start time in ns. (if HCC_PROFILE_VERBOSE & 0x2)
 * STOP: command stop time in ns. (if HCC_PROFILE_VERBOSE & 0x2)
@@ -677,10 +723,12 @@ Barrier Commands
 
 Barrier commands are only enabled if HCC_PROFILE_VERBOSE 0x10
 
-An example barrier command with full vebosity::
- 
+An example barrier command with full vebosity
+
+.. code:: sh
+
  profile: barrier; deps:0_acq:none_rel:sys;  5.3 us;   94858731419410; 94858731424690; # 0.0.2;
- PROFILE:  TYPE;   BARRIER_NAME           ;  DURATION; START         ; STOP          ; ID    ; 
+ PROFILE:  TYPE;   BARRIER_NAME           ;  DURATION; START         ; STOP          ; ID    ;
 
 * PROFILE: always "profile:" to distinguish it from other output.
 * TYPE: the command type: either kernel, copy, copyslo, or barrier. The examples and descriptions in this section are all copy commands. Copy indicates that the runtime used a call to the fast hsa memory copy routine while copyslo indicates that the copy was implemented with staging buffers or another less optimal path. copy computes the commands using device-side timestamps while copyslo computes the bandwidth based on host timestamps.
@@ -722,14 +770,14 @@ HIP provides a C++ syntax that is suitable for compiling most code that commonly
 
 This section describes the built-in variables and functions accessible from the HIP kernel. It’s intended for readers who are familiar with Cuda kernel syntax and want to understand how HIP is different.
 
-  * :ref:`HIP-GUIDE` 
+  * :ref:`HIP-GUIDE`
 
 
 HIP Best Practices
 ==================
 
- * :ref:`HIP-porting-guide` 
- * :ref:`HIP-terminology` 
+ * :ref:`HIP-porting-guide`
+ * :ref:`HIP-terminology`
  * :ref:`hip_profiling`
  * :ref:`HIP_Debugging`
  * :ref:`Kernel_language`
@@ -738,7 +786,7 @@ HIP Best Practices
  * :ref:`hipporting-driver-api`
  * :ref:`CUDAAPIHIP`
  * :ref:`CUDAAPIHIPTEXTURE`
- * :ref:`HIP-FAQ` 
+ * :ref:`HIP-FAQ`
  * :ref:`HIP-Term2`
 
 
@@ -752,6 +800,3 @@ OpenCL Best Practices
 ======================
 
 * :ref:`Optimization-Opencl`
-
-
-

--- a/ROCm_API_References/HCC-API.rst
+++ b/ROCm_API_References/HCC-API.rst
@@ -26,17 +26,17 @@ HC comes with two header files as of now:
 
 Most HC APIs are stored under "hc" namespace, and the class name is the same as their counterpart in C++AMP "Concurrency" namespace. Users of C++AMP should find it easy to switch from C++AMP to HC.
 
-=================================== ======================
+=================================== =========================
 C++AMP					     HC
-=================================== ======================
-Concurrency::accelerator	     hc::accelerator
-Concurrency::accelerator_view	     hc::accelerator_view
-Concurrency::extent		     hc::extent
-Concurrency::index		     hc::index
-Concurrency::completion_future	     hc::completion_future
-Concurrency::array		     hc::array
-Concurrency::array_view		     hc::array_view
-=================================== ======================
+=================================== =========================
+``Concurrency::accelerator``	      ``hc::accelerator``
+``Concurrency::accelerator_view``	``hc::accelerator_view``
+``Concurrency::extent``		         ``hc::extent``
+``Concurrency::index``		         ``hc::index``
+``Concurrency::completion_future``  ``hc::completion_future``
+``Concurrency::array``	            ``hc::array``
+``Concurrency::array_view``		   ``hc::array_view``
+=================================== =========================
 
 How to build programs with HC API
 ************************************
@@ -52,36 +52,36 @@ HCC built-in macros
 ********************
 Built-in macros:
 
-=================== ==========================================================================
+====================== ===============================================================================
 Macro							Meaning
-=================== ==========================================================================
-__HCC__			always be 1
-__hcc_major__		major version number of HCC
-__hcc_minor__		minor version number of HCC
-__hcc_patchlevel__	patchlevel of HCC
-__hcc_version__		combined string of __hcc_major__, __hcc_minor__, __hcc_patchlevel__
-=================== ==========================================================================
+====================== ===============================================================================
+``__HCC__``			     always be 1
+``__hcc_major__``	     major version number of HCC
+``__hcc_minor__``	     minor version number of HCC
+``__hcc_patchlevel__`` patchlevel of HCC
+``__hcc_version__``	  combined string of ``__hcc_major__``, ``__hcc_minor__``, ``__hcc_patchlevel__``
+====================== ===============================================================================
 
-The rule for __hcc_patchlevel__ is: yyWW-(HCC driver git commit #)-(HCC clang git commit #)
+The rule for ``__hcc_patchlevel__`` is: yyWW-(HCC driver git commit #)-(HCC clang git commit #)
 
    * yy stands for the last 2 digits of the year
    * WW stands for the week number of the year
 Macros for language modes in use:
 
-================ =============================================
-Macro				Meaning.
-================ =============================================
-__KALMAR_AMP__    1 in case in C++ AMP mode (-std=c++amp)
-__KALMAR_HC__	  1 in case in HC mode (-hc)
-================ =============================================
+================== ==========================================================================
+Macro				    Meaning.
+================== ==========================================================================
+``__KALMAR_AMP__`` 1 in case in C++ AMP mode (-std=c++amp; **Removed from ROCm 2.0 onwards**)
+``__KALMAR_HC__``	 1 in case in HC mode (-hc)
+================== ==========================================================================
 Compilation mode: HCC is a single-source compiler where kernel codes and host codes can reside in the same file. Internally HCC would trigger 2 compilation iterations, and the following macros can be user by user programs to determine which mode the compiler is in.
 
-========================= ===================================================================
-Macro				Meaning
-========================= ===================================================================
-__KALMAR_ACCELERATOR__	   not 0 in case the compiler runs in kernel code compilation mode
-__KALMAR_CPU__	           not 0 in case the compiler runs in host code compilation mode
-========================= ===================================================================
+========================== ===============================================================
+Macro				            Meaning
+========================== ===============================================================
+``__KALMAR_ACCELERATOR__``	not 0 in case the compiler runs in kernel code compilation mode
+``__KALMAR_CPU__``	      not 0 in case the compiler runs in host code compilation mode
+========================== ===============================================================
 
 HC-specific features
 *********************
@@ -103,7 +103,7 @@ HC supports the automatic synchronization behavior as in C++ AMP. In addition, H
 
 Annotation of device functions
 ********************************
-C++ AMP uses the restrict(amp) keyword to annotatate functions that runs on the device.
+C++ AMP uses the restrict(amp) keyword to annotate functions that runs on the device.
 
 ``` void foo() restrict(amp) { .. } ... parallel_for_each(...,[=] () restrict(amp) { foo(); });
 
@@ -144,37 +144,3 @@ HC supports capturing memory pointer by a GPU kernel.
 ``` // allocate GPU memory through the HSA API int* gpu_pointer; hsa_memory_allocate(..., &gpu_pointer); ... parallel_for_each(ext, [=](index i) [[hc]] { gpu_pointer[i[0]]++; }
 
 ``` For HSA APUs that supports system wide shared virtual memory, a GPU kernel can directly access system memory allocated by the host: ``` int* cpu_memory = (int*) malloc(...); ... parallel_for_each(ext, [=](index i) [[hc]] { cpu_memory[i[0]]++; }); ```
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/ROCm_Tools/ROCm-Tools.rst
+++ b/ROCm_Tools/ROCm-Tools.rst
@@ -5,7 +5,7 @@
 ROCm Tools
 =====================
 
-HCC  
+HCC
 ====
 
 **HCC is an Open Source, Optimizing C++ Compiler for Heterogeneous Compute**
@@ -19,7 +19,9 @@ Download HCC
 
 The project now employs git submodules to manage external components it depends upon. It it advised to add --recursive when you clone the project so all submodules are fetched automatically.
 
-For example: ::
+For example:
+
+.. code:: sh
 
   # automatically fetches all submodules
   git clone --recursive -b clang_tot_upgrade https://github.com/RadeonOpenCompute/hcc.git
@@ -31,35 +33,51 @@ Build HCC from source
 #######################
 
 To configure and build HCC from source, use the following steps:
-::
+
+.. code:: sh
+
   mkdir -p build; cd build
   cmake -DCMAKE_BUILD_TYPE=Release ..
   make
 
 To install it, use the following steps:
-::
+
+.. code:: sh
+
   sudo make install
 
 Use HCC
 ########
 
 For C++AMP source codes:
-::
+
+.. code:: sh
+
   hcc `clamp-config --cxxflags --ldflags` foo.cpp
 
+**WARNING: From ROCm version 2.0 onwards C++AMP is no longer available in HCC.**
+
 For HC source codes:
-::
+
+.. code:: sh
+
   hcc `hcc-config --cxxflags --ldflags` foo.cpp
 
 In case you build HCC from source and want to use the compiled binaries directly in the build directory:
 
 For C++AMP source codes:
-::
+
+.. code:: sh
+
   # notice the --build flag
   bin/hcc `bin/clamp-config --build --cxxflags --ldflags` foo.cpp
 
+**WARNING: From ROCm version 2.0 onwards C++AMP is no longer available in HCC.**
+
 For HC source codes:
-::
+
+.. code:: sh
+
   # notice the --build flag
   bin/hcc `bin/hcc-config --build --cxxflags --ldflags` foo.cpp
 
@@ -71,9 +89,11 @@ HCC now supports having multiple GCN ISAs in one executable file. You can do it 
 
 It's possible to specify multiple ``--amdgpu-target=``option.
 
-Example: ::
+Example:
 
- # ISA for Hawaii(gfx701), Carrizo(gfx801), Tonga(gfx802) and Fiji(gfx803) would 
+.. code:: sh
+
+ # ISA for Hawaii(gfx701), Carrizo(gfx801), Tonga(gfx802) and Fiji(gfx803) would
  # be produced
   hcc `hcc-config --cxxflags --ldflags` \
     --amdgpu-target=gfx701 \
@@ -84,11 +104,12 @@ Example: ::
 
 **use ``HCC_AMDGPU_TARGET`` env var**
 
-use ``,`` to delimit each AMDGPU target in HCC. Example: 
-::
-  
+use ``,`` to delimit each AMDGPU target in HCC. Example:
+
+.. code:: sh
+
   export HCC_AMDGPU_TARGET=gfx701,gfx801,gfx802,gfx803
-  # ISA for Hawaii(gfx701), Carrizo(gfx801), Tonga(gfx802) and Fiji(gfx803) would 
+  # ISA for Hawaii(gfx701), Carrizo(gfx801), Tonga(gfx802) and Fiji(gfx803) would
   # be produced
   hcc `hcc-config --cxxflags --ldflags` foo.cpp
 
@@ -96,10 +117,12 @@ use ``,`` to delimit each AMDGPU target in HCC. Example:
 
 If you build HCC from source, it's possible to configure it to automatically produce multiple ISAs via `HSA_AMDGPU_GPU_TARGET` CMake variable.
 
-Use ``;`` to delimit each AMDGPU target. 
-Example: ::
+Use ``;`` to delimit each AMDGPU target.
+Example:
 
- # ISA for Hawaii(gfx701), Carrizo(gfx801), Tonga(gfx802) and Fiji(gfx803) would 
+.. code:: sh
+
+ # ISA for Hawaii(gfx701), Carrizo(gfx801), Tonga(gfx802) and Fiji(gfx803) would
  # be produced by default
  cmake \
     -DCMAKE_BUILD_TYPE=Release \
@@ -112,7 +135,9 @@ CodeXL Activity Logger
 
 To enable the `CodeXL Activity Logger <https://github.com/RadeonOpenCompute/ROCm-Profiler/tree/master/CXLActivityLogger>`_, use the  ``USE_CODEXL_ACTIVITY_LOGGER`` environment variable.
 
-Configure the build in the following way: ::
+Configure the build in the following way:
+
+.. code:: sh
 
   cmake \
     -DCMAKE_BUILD_TYPE=Release \
@@ -121,8 +146,10 @@ Configure the build in the following way: ::
     -DUSE_CODEXL_ACTIVITY_LOGGER=1 \
     <ToT HCC checkout directory>
 
-In your application compiled using hcc, include the CodeXL Activiy Logger header: 
-::
+In your application compiled using hcc, include the CodeXL Activiy Logger header:
+
+.. code:: sh
+
   #include <CXLActivityLogger.h>
 
 For information about the usage of the Activity Logger for profiling, please refer to its `documentation <https://github.com/RadeonOpenCompute/ROCm-Profiler/blob/master/CXLActivityLogger/doc/AMDTActivityLogger.pdf>`_.
@@ -133,7 +160,9 @@ HCC with ThinLTO Linking
 To enable the ThinLTO link time, use the ``KMTHINLTO`` environment variable.
 
 Set up your environment in the following way:
-::
+
+.. code:: sh
+
   export KMTHINLTO=1
 
 **ThinLTO Phase 1 - Implemented**
@@ -161,7 +190,7 @@ DS Permute Instructions
 **************************
 Two new instructions, ds_permute_b32 and ds_bpermute_b32, allow VGPR data to move between lanes on the basis of an index from another VGPR. These instructions use LDS hardware to route data between the 64 lanes, but they don’t write to LDS memory. The difference between them is what to index: the source-lane ID or the destination-lane ID. In other words, ds_permute_b32 says “put my lane data in lane i,” and ds_bpermute_b32 says “read data from lane i.” The GCN ISA Reference Guide provides a more formal description. The test kernel is simple: read the initial data and indices from memory into GPRs, do the permutation in the GPRs and write the data back to memory. An analogous OpenCL kernel would have this form:
 
-::
+.. code:: cpp
 
   __kernel void hello_world(__global const uint * in, __global const uint * index, __global uint * out)
   {
@@ -173,7 +202,7 @@ Passing Parameters to a Kernel
 *******************************
 Formal HSA arguments are passed to a kernel using a special read-only memory segment called kernarg. Before a wavefront starts, the base address of the kernarg segment is written to an SGPR pair. The memory layout of variables in kernarg must employ the same order as the list of kernel formal arguments, starting at offset 0, with no padding between variables—except to honor the requirements of natural alignment and any align qualifier. The example host program must create the kernarg segment and fill it with the buffer base addresses. The HSA host code might look like the following:
 
-::
+.. code:: cpp
 
   /*
   * This is the host-side representation of the kernel arguments that the simplePermute kernel expects.
@@ -193,7 +222,7 @@ Formal HSA arguments are passed to a kernel using a special read-only memory seg
   aql->kernarg_address = args;
   /*
   * Write the args directly to the kernargs buffer;
-  * the code assumes that memory is already allocated for the 
+  * the code assumes that memory is already allocated for the
   * buffers that in_ptr, index_ptr and out_ptr point to
   */
   args->in = in_ptr;
@@ -202,7 +231,7 @@ Formal HSA arguments are passed to a kernel using a special read-only memory seg
 
 The host program should also allocate memory for the in, index and out buffers. In the GitHub repository, all the run-time-related  stuff is hidden in the Dispatch and Buffer classes, so the sample code looks much cleaner:
 
-::
+.. code:: cpp
 
   // Create Kernarg segment
   if (!AllocateKernarg(3 * sizeof(void*))) { return false; }
@@ -234,7 +263,7 @@ Initial Wavefront and Register State To launch a kernel in real hardware, the ru
    .text
    .p2align 8
    .amdgpu_hsa_kernel hello_world
- 
+
    hello_world:
 
    .amd_kernel_code_t
@@ -337,7 +366,7 @@ Compiling GCN ASM Kernel Into Hsaco
 **************************************
 The next step is to produce a Hsaco from the ASM source. LLVM has added support for the AMDGCN assembler, so you can use Clang to do all the necessary magic:
 
-::
+.. code:: sh
 
   clang -x assembler -target amdgcn--amdhsa -mcpu=fiji -c -o test.o asm_source.s
 
@@ -378,10 +407,10 @@ Top-level CMakeLists.txt is provided to build everything included. The following
 
 To build everything, create build directory and run cmake and make:
 
-::
+.. code:: sh
 
   mkdir build
-  cd build  
+  cd build
   cmake -DLLVM_DIR=/srv/git/llvm.git/build ..
   make
 
@@ -391,20 +420,26 @@ Use cases
 **********
 **Assembling to code object with llvm-mc from command line**
 
-The following llvm-mc command line produces ELF object asm.o from assembly source asm.s: ::
+The following llvm-mc command line produces ELF object asm.o from assembly source asm.s:
+
+.. code:: sh
 
   llvm-mc -arch=amdgcn -mcpu=fiji -filetype=obj -o asm.o asm.s
 
 **Assembling to raw instruction stream with llvm-mc from command line**
 
-It is possible to extract contents of .text section after assembling to code object: ::
+It is possible to extract contents of .text section after assembling to code object:
+
+.. code:: sh
 
   llvm-mc -arch=amdgcn -mcpu=fiji -filetype=obj -o asm.o asm.s
   objdump -h asm.o | grep .text | awk '{print "dd if='asm.o' of='asm' bs=1 count=$[0x" $3 "] skip=$[0x" $6 "]"}' | bash
 
 **Disassembling code object from command line**
 
-The following command line may be used to dump contents of code object: ::
+The following command line may be used to dump contents of code object:
+
+.. code:: sh
 
   llvm-objdump -disassemble -mcpu=fiji asm.o
 
@@ -412,7 +447,9 @@ This includes text disassembly of .text section.
 
 **Disassembling raw instruction stream from command line**
 
-The following command line may be used to disassemble raw instruction stream (without ELF structure): ::
+The following command line may be used to disassemble raw instruction stream (without ELF structure):
+
+.. code:: sh
 
   hexdump -v -e '/1 "0x%02X "' asm | llvm-mc -arch=amdgcn -mcpu=fiji -disassemble
 
@@ -431,7 +468,9 @@ Refer to examples/api/disassemble.
 Note that normally standard lld and Code Object version 2 should be used which is closer to standard ELF format.
 
 amdphdrs (now obsolete) is complimentary utility that can be used to produce AMDGPU Code Object version 1.
-For example, given assembly source in asm.s, the following will assemble it and link using amdphdrs: ::
+For example, given assembly source in asm.s, the following will assemble it and link using amdphdrs:
+
+.. code:: sh
 
   llvm-mc -arch=amdgcn -mcpu=fiji -filetype=obj -o asm.o asm.s
   andphdrs asm.o asm.co
@@ -443,29 +482,41 @@ Differences between LLVM AMDGPU Assembler and AMD SP3 assembler
 SP3 supports proprietary set of macros/tools. sp3_to_mc.pl script attempts to translate them into GAS syntax understood by llvm-mc.
 flat_atomic_cmpswap instruction has 32-bit destination
 
-LLVM AMDGPU: ::
+LLVM AMDGPU:
+
+::
 
   flat_atomic_cmpswap v7, v[9:10], v[7:8]
 
-SP3: ::
+SP3:
+
+::
 
   flat_atomic_cmpswap v[7:8], v[9:10], v[7:8]
 
 Atomic instructions that return value should have glc flag explicitly
 
-LLVM AMDGPU: flat_atomic_swap_x2 v[0:1], v[0:1], v[2:3] glc
+LLVM AMDGPU:
 
-SP3 flat_atomic_swap_x2 v[0:1], v[0:1], v[2:3]
+::
+
+  flat_atomic_swap_x2 v[0:1], v[0:1], v[2:3] glc
+
+SP3:
+
+::
+
+  flat_atomic_swap_x2 v[0:1], v[0:1], v[2:3]
 
 References
 ***********
    *  `LLVM Use Guide for AMDGPU Back-End <http://llvm.org/docs/AMDGPUUsage.html>`_
-   *  AMD ISA Documents 
+   *  AMD ISA Documents
        *  `AMD GCN3 Instruction Set Architecture (2016) <http://developer.amd.com/wordpress/media/2013/12/AMD_GCN3_Instruction_Set_Architecture_rev1.1.pdf>`_
        *  `AMD_Southern_Islands_Instruction_Set_Architecture <https://developer.amd.com/wordpress/media/2012/12/AMD_Southern_Islands_Instruction_Set_Architecture.pdf>`_
 
 
-ROC Profiler  
+ROC Profiler
 ============
 
 HW specific low-level performance analysis API, 'rocprofiler' library and 'rocprof' tool for profiling of GPU compute applications. The profiling includes HW performance counters with complex performance metrics and HW traces.
@@ -482,7 +533,9 @@ Download
 ########
 
 To clone ROC Profiler from GitHub use the folowing command:
-::
+
+.. code:: sh
+
   git clone https://github.com/ROCmSoftwarePlatform/rocprofiler
 
 The library source tree:
@@ -507,13 +560,17 @@ Build
 #####
 
 Build environment:
-::
+
+.. code:: sh
+
   export CMAKE_PREFIX_PATH=<path to hsa-runtime includes>:<path to hsa-runtime library>
   export CMAKE_BUILD_TYPE=<debug|release> # release by default
   export CMAKE_DEBUG_TRACE=1 # to enable debug tracing
-  
+
 To configure, build, install to /opt/rocm/rocprofiler:
-::
+
+.. code:: sh
+
   mkdir -p build
   cd build
   export CMAKE_PREFIX_PATH=/opt/rocm/lib:/opt/rocm/include/hsa
@@ -522,7 +579,9 @@ To configure, build, install to /opt/rocm/rocprofiler:
   sudo make install
 
 To test the built library:
-::
+
+.. code:: sh
+
   cd build
   ./run.sh
 
@@ -530,7 +589,9 @@ Profiling Tool 'rocprof' Usage
 ##############################
 
 The following shows the command-line usage of the 'rocprof' tool:
-::
+
+.. code:: sh
+
   rpl_run.sh [-h] [--list-basic] [--list-derived] [-i <input .txt/.xml file>] [-o <output CSV file>] <app command line>
 
   Options:
@@ -632,7 +693,7 @@ different version set the LD_LIBRARY_PATH, for example:
 To display the machine code instructions of wavefronts, together with
 the source text location, the ROCr Debug Agent uses the llvm-objdump
 tool. Ensure that a version that supports AMD GCN GPUs is on your
-’$PATH`. For example, for ROCm 1.9.2:
+``$PATH``. For example, for ROCm 1.9.2:
 
 .. code:: sh
 
@@ -865,7 +926,7 @@ What's New
        * Improves display of pointer parameters for some HSA APIs in the ATP file
        * Fixes an issue with parsing an ATP file which has non-ascii characters (affected Summary page generation and display within 		 CodeXL)
        * ROCm/HSA: Fixes several issues with incorrect or missing data transfer timestamps.
-       
+
 System Requirements
 ********************
   * An AMD Radeon GCN-based GPU or APU
@@ -928,7 +989,7 @@ Known Issues
        * When collecting a trace for an application that performs memory transfers using hsa_amd_memory_async_copy, if the 		 application asks for the data transfer timestamps directly, it will not get correct timestamps. The profiler will show the 		 correct timestamps, however.
        * When collecting an aql packet trace, if the application asks for the kernel dispatch timestamps directly, it will not get 		 correct timestamps. The profiler will show the correct timestamps, however.
        * When the rocm-profiler package (.deb or .rpm) is installed along with rocm, it may not be able to generate the default 	 single-pass counter files. If you do not see counter files in /opt/rocm/profiler/counterfiles, you can generate them 		 manually with this command: "sudo /opt/rocm/profiler/bin/CodeXLGpuProfiler --list --outputfile /opt/rocm/profiler/	  	   counterfiles/counters --maxpassperfile 1"
-       
+
 CodeXL
 =========
 CodeXL is a comprehensive tool suite that enables developers to harness the benefits of CPUs, GPUs and APUs. It includes powerful GPU debugging, comprehensive GPU and CPU profiling, DirectX12® Frame Analysis, static OpenCL™, OpenGL®, Vulkan® and DirectX® kernel/shader analysis capabilities, and APU/CPU/GPU power profiling, enhancing accessibility for software developers to enter the era of heterogeneous computing. CodeXL is available both as a Visual Studio® extension and a standalone user interface application for Windows® and Linux®.


### PR DESCRIPTION
This adds the required documentation changes for version 2.0, which removes support for C++AMP. I've also taken the chance to clean up some of the more annoying misuses of rst and to annotate code blocks with language information, where feasible.