### PR TITLE
isuues found in hipCaffe quickstart guide

### DIFF
--- a/Tutorial/hipCaffe .rst
+++ b/Tutorial/hipCaffe .rst
@@ -10,7 +10,7 @@ Install ROCm
 -------------
 Here are the main ROCm components we’ll be using::
 
- sudo apt-get install rocm
+ sudo apt install rocm-dkms
  sudo apt-get install rocm-libs
  sudo apt-get install miopen-hip miopengemm
  
@@ -37,7 +37,7 @@ Test a simple HIP sample::
  
  make
  
- ./square.hip.out
+ ./square.out
   
 Install hipCaffe
 ----------------


### PR DESCRIPTION
(1)I found sudo apt install rocm doesn't work any more ,it should be change to   sudo apt install rocm-dkms
(2)in the Verify ROCm part , the output file is  ./square.out