### PR TITLE
Fix corrupted Debian installation instructions

### DIFF
--- a/Installation_Guide/Installation-Guide.rst
+++ b/Installation_Guide/Installation-Guide.rst
@@ -59,11 +59,9 @@ For Debian-based systems like Ubuntu, configure the Debian ROCm repository as fo
 
 ::
 
-    wget -q0 –http://repo.radeon.com/rocm/apt/debian/rocm.gpg.key | 
-
-    sudo apt-key add -echo 'deb [arch=amd64] http://repo.radeon.com/rocm/apt/debian/ xenial main' | 
-
-    sudo tee /etc/apt/sources.list.d/rocm.list
+    wget -q -O - http://repo.radeon.com/rocm/apt/debian/rocm.gpg.key |  sudo apt-key add -
+    
+    echo 'deb [arch=amd64] http://repo.radeon.com/rocm/apt/debian/ xenial main' | sudo tee /etc/apt/sources.list.d/rocm.list
 
 
 The gpg key may change; ensure it is updated when installing a new release. If the key signature verification fails while updating, re-add the key from the ROCm apt repository.

--- a/Installation_Guide/Quick Start Installation Guide.rst
+++ b/Installation_Guide/Quick Start Installation Guide.rst
@@ -61,11 +61,9 @@ For Debian-based systems like Ubuntu, configure the Debian ROCm repository as fo
 
 ::
 
-    wget -q0 –http://repo.radeon.com/rocm/apt/debian/rocm.gpg.key | 
+    wget -q -O - http://repo.radeon.com/rocm/apt/debian/rocm.gpg.key | sudo apt-key add -
 
-    sudo apt-key add -echo 'deb [arch=amd64] http://repo.radeon.com/rocm/apt/debian/ xenial main' | 
-
-    sudo tee /etc/apt/sources.list.d/rocm.list
+    echo 'deb [arch=amd64] http://repo.radeon.com/rocm/apt/debian/ xenial main' | sudo tee /etc/apt/sources.list.d/rocm.list
 
 
 The gpg key may change; ensure it is updated when installing a new release. If the key signature verification fails while updating, re-add the key from the ROCm apt repository.


### PR DESCRIPTION
Fix corrupted Debian installation instructions introduced by  4be85f2c9227c95ed4bf6fd3ac35b4e42e1e859b and others @sriharikarnam @Rmalavally 

Also: Should  `Installation-Guide.rst` be titled "**QuickStart** Installation Guide" anymore?