### PR TITLE
Missing pipes in Ubuntu step 6

### DIFF
--- a/Installation_Guide/Installation-Guide.rst
+++ b/Installation_Guide/Installation-Guide.rst
@@ -99,11 +99,9 @@ The current rocm.gpg.key is not available in a standard key ring distribution, b
 
 ::
 
-     echo 'ADD_EXTRA_GROUPS=1' 
-     sudo tee -a /etc/adduser.conf
+     echo 'ADD_EXTRA_GROUPS=1' | sudo tee -a /etc/adduser.conf
 
-     echo 'EXTRA_GROUPS=video'
-     sudo tee -a /etc/adduser.conf
+     echo 'EXTRA_GROUPS=video' | sudo tee -a /etc/adduser.conf
 
 7. Restart the system.
 

--- a/Installation_Guide/Installation-Guide.rst
+++ b/Installation_Guide/Installation-Guide.rst
@@ -156,7 +156,7 @@ You can install the ROCm user-level software without installing the AMD's custom
 
   sudo apt update	
   sudo apt install rocm-dev	
-  echo 'SUBSYSTEM=="kfd", KERNEL=="kfd", TAG+="uaccess", GROUP="video"' 
+  echo 'SUBSYSTEM=="kfd", KERNEL=="kfd", TAG+="uaccess", GROUP="video"' |
   sudo tee /etc/udev/rules.d/70-kfd.rules
 
 


### PR DESCRIPTION
Added missing pipes between the `echo` and `tee` commands in step 6 of the Ubuntu section, RE:  #64 