### PR TITLE
Corrected dash character in wget command.

### DIFF
--- a/Installation_Guide/Installation-Guide.rst
+++ b/Installation_Guide/Installation-Guide.rst
@@ -58,7 +58,7 @@ For Debian-based systems like Ubuntu, configure the Debian ROCm repository as fo
 
 ::
 
-    wget -q -O – http://repo.radeon.com/rocm/apt/debian/rocm.gpg.key | sudo apt-key add -
+    wget -q --O - http://repo.radeon.com/rocm/apt/debian/rocm.gpg.key | sudo apt-key add -
 
     echo 'deb [arch=amd64] http://repo.radeon.com/rocm/apt/debian/ xenial main' | sudo tee /etc/apt/sources.list.d/rocm.list
 


### PR DESCRIPTION
Corrected dash character in wget command that retrieves ROCm GPG key.