### PR TITLE
Fix corrupted Debian installation instructions

### DIFF
--- a/Installation_Guide/Installation-Guide.rst
+++ b/Installation_Guide/Installation-Guide.rst
@@ -58,7 +58,7 @@ For Debian-based systems like Ubuntu, configure the Debian ROCm repository as fo
 
 ::
 
-    wget -q -O – http://repo.radeon.com/rocm/apt/debian/rocm.gpg.key | sudo apt-key add -
+    wget -q -O - http://repo.radeon.com/rocm/apt/debian/rocm.gpg.key | sudo apt-key add -
 
     echo 'deb [arch=amd64] http://repo.radeon.com/rocm/apt/debian/ xenial main' | sudo tee /etc/apt/sources.list.d/rocm.list
 

--- a/Installation_Guide/Quick Start Installation Guide.rst
+++ b/Installation_Guide/Quick Start Installation Guide.rst
@@ -61,11 +61,9 @@ For Debian-based systems like Ubuntu, configure the Debian ROCm repository as fo
 
 ::
 
-    wget -q0 –http://repo.radeon.com/rocm/apt/debian/rocm.gpg.key | 
+    wget -q -O - http://repo.radeon.com/rocm/apt/debian/rocm.gpg.key | sudo apt-key add -
 
-    sudo apt-key add -echo 'deb [arch=amd64] http://repo.radeon.com/rocm/apt/debian/ xenial main' | 
-
-    sudo tee /etc/apt/sources.list.d/rocm.list
+    echo 'deb [arch=amd64] http://repo.radeon.com/rocm/apt/debian/ xenial main' | sudo tee /etc/apt/sources.list.d/rocm.list
 
 
 The gpg key may change; ensure it is updated when installing a new release. If the key signature verification fails while updating, re-add the key from the ROCm apt repository.


### PR DESCRIPTION
As per PR #63, this fixes the Debian installation instructions.

There are 3 commonly-repeated problems occurring:
1. The use of a Unicode - (dash) instead of the ASCII one
2. The use of `-q0` or `-qO` instead of the correct `-q -O -` command arguments.
3. The wrong breaking up of the lines. 