### PR TITLE
Add recursive flag in PyTorch cloning command

### DIFF
--- a/Deep_learning/Deep-learning.rst
+++ b/Deep_learning/Deep-learning.rst
@@ -144,7 +144,7 @@ Recommended:Install using published PyTorch ROCm docker image:
   git clone https://github.com/pytorch/pytorch.git
   cd pytorch
   git submodule init
-  git submodule update
+  git submodule update --recursive
 
 4. Start a docker container using the downloaded image:
 


### PR DESCRIPTION
This is a issue I encountered while I was building PyTorch where some of the module cannot find it's dependency because the lack of necessary modules.