### PR TITLE
Removed dangling quote from cmake command paths

### DIFF
--- a/Installation_Guide/HIP-Installation.rst
+++ b/Installation_Guide/HIP-Installation.rst
@@ -39,7 +39,7 @@ HIP-Clang can be built manually:
    	git clone -b roc-4.0.x  https://github.com/RadeonOpenCompute/llvm-project.git
 	cd llvm-project
 	mkdir -p build && cd build
-	cmake -DCMAKE_INSTALL_PREFIX=/opt/rocm/llvm -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_ASSERTIONS=1 -DLLVM_TARGETS_TO_BUILD="AMDGPU;X86" -DLLVM_ENABLE_PROJECTS="clang;lld;compiler-rt" ../llvm”
+	cmake -DCMAKE_INSTALL_PREFIX=/opt/rocm/llvm -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_ASSERTIONS=1 -DLLVM_TARGETS_TO_BUILD="AMDGPU;X86" -DLLVM_ENABLE_PROJECTS="clang;lld;compiler-rt" ../llvm
 	make -j
 	sudo make install
 
@@ -53,7 +53,7 @@ The ROCm device library can be manually built as following,
 	git clone -b roc-4.0.x  https://github.com/RadeonOpenCompute/ROCm-Device-Libs.git
 	cd ROCm-Device-Libs
 	mkdir -p build && cd build
-	CC=clang CXX=clang++ cmake -DCMAKE_INSTALL_PREFIX=/opt/rocm/llvm -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_ASSERTIONS=1 -DLLVM_TARGETS_TO_BUILD="AMDGPU;X86" -DLLVM_ENABLE_PROJECTS="clang;lld;compiler-rt" ../llvm”
+	CC=clang CXX=clang++ cmake -DCMAKE_INSTALL_PREFIX=/opt/rocm/llvm -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_ASSERTIONS=1 -DLLVM_TARGETS_TO_BUILD="AMDGPU;X86" -DLLVM_ENABLE_PROJECTS="clang;lld;compiler-rt" ../llvm
 	make -j
 	sudo make install
 


### PR DESCRIPTION
In clang HIP and rocm compilation instructions, a dangling quote after the path prevents the command from executing properly. After the quote was removed the command executed successfully.

Added note: the quote was a curved quote, so it appears to get read as part of the path