### PR TITLE
Add hipSOLVER documentation

### DIFF
--- a/ROCm_Libraries/ROCm_Libraries.rst
+++ b/ROCm_Libraries/ROCm_Libraries.rst
@@ -6,6 +6,10 @@ ROCm Libraries
 
 Libraries are listed alphabetically below.
 
+`MIGraphX User Guide <https://rocmsoftwareplatform.github.io/AMDMIGraphX/doc/html/>`_
+
+`RCCL User Guide <https://rccl.readthedocs.io/>`_
+
 `rocALUTION User Guide <https://rocalution.readthedocs.io/>`_
 
 `rocBLAS User Guide <https://rocblas.readthedocs.io/>`_
@@ -14,15 +18,11 @@ Libraries are listed alphabetically below.
 
 `rocRAND User Guide <https://rocrand.readthedocs.io/>`_
 
-`RCCL User Guide <https://rccl.readthedocs.io/>`_
-
 `rocSOLVER User Guide <https://rocsolver.readthedocs.io/>`_
 
 `rocSPARSE User Guide <https://rocsparse.readthedocs.io/>`_
 
 `rocThrust User Guide <https://rocthrust.readthedocs.io/>`_
-
-`MIGraphX User Guide <https://rocmsoftwareplatform.github.io/AMDMIGraphX/doc/html/>`_
 
 
 *********************

--- a/ROCm_Libraries/ROCm_Libraries.rst
+++ b/ROCm_Libraries/ROCm_Libraries.rst
@@ -6,6 +6,8 @@ ROCm Libraries
 
 Libraries are listed alphabetically below.
 
+`hipSOLVER User Guide <https://hipsolver.readthedocs.io/>`_
+
 `MIGraphX User Guide <https://rocmsoftwareplatform.github.io/AMDMIGraphX/doc/html/>`_
 
 `RCCL User Guide <https://rccl.readthedocs.io/>`_


### PR DESCRIPTION
Adds hipSOLVER to ROCm_Libraries.rst. Also alphabetizes the libraries in ROCm_Libraries.rst to reflect the statement "Libraries are listed alphabetically below".