### PR TITLE
Broken link

### DIFF
--- a/Current_Release_Notes/Current-Release-Notes.rst
+++ b/Current_Release_Notes/Current-Release-Notes.rst
@@ -909,7 +909,7 @@ This issue is currently under investigation and will be fixed in a future releas
 
 For more information, refer to the ROCgdb User Guide at,
 
-https://github.com/RadeonOpenCompute/ROCm/blob/master/AMD_ROCDebugger_User_Guide.pdf
+https://github.com/RadeonOpenCompute/ROCm/blob/master/ROCDebugger_User_Guide.pdf
 
 
 clinfo and rocminfo Do Not Display Marketing Name


### PR DESCRIPTION
This fixes a broken link in documentation to rocgdb user guide.