### PR TITLE
Update HIP-Installation.rst

### DIFF
--- a/Installation_Guide/HIP-Installation.rst
+++ b/Installation_Guide/HIP-Installation.rst
@@ -67,11 +67,11 @@ HIP-nvcc is the compiler for HIP program compilation on NVIDIA platform.
    guide available
    `here <https://rocm.github.io/ROCmInstall.html#installing-from-amd-rocm-repositories>`__.
    
--  Install the "hip-runtime-nvidia" and "hip-devel" package. This will install CUDA SDK and the HIP porting layer.
+-  Install the "hip-runtime-nvidia" and "hip-dev" package. This will install CUDA SDK and the HIP porting layer.
 
 ::
 
- 		apt-get install hip-runtime-nvidia hip-devel
+ 		apt-get install hip-runtime-nvidia hip-dev
 		
 
 -  Default paths and environment variables:


### PR DESCRIPTION
The package name for NVIDIA install should be "hip-dev" as in (hip-dev), and not "hip-devel"
this is the location of the package, for reference:
http://repo.radeon.com/rocm/apt/4.5.1/pool/main/h/hip-dev/