### PR TITLE
Fix links to PDFs in ROCm 4.5 documentation

### DIFF
--- a/Non-Doxygen_RST/rocmrelnotes/Release-Notes.rst
+++ b/Non-Doxygen_RST/rocmrelnotes/Release-Notes.rst
@@ -93,7 +93,7 @@ Extract only ROCm code objects matching regex over Target ID
 
 For more information, refer to the HIP Programming Guide at:  
 
-https://github.com/RadeonOpenCompute/ROCm/blob/master/AMD_HIP_Programming_Guide.pdf
+https://github.com/RadeonOpenCompute/ROCm/blob/rocm-4.5.2/AMD_HIP_Programming_Guide.pdf
 
 
 
@@ -204,7 +204,7 @@ AMD Instinct™ High Performance Computing and Tuning
 
 - New - AMD Instinct™ High Performance Computing and Tuning Guide 
 
-  see `AMD Instinct™ High Performance Computing and Tuning Guide <https://github.com/RadeonOpenCompute/ROCm/blob/master/AMD%20Instinct%E2%84%A2High%20Performance%20Computing%20and%20Tuning%20Guide.pdf>`__
+  see `AMD Instinct™ High Performance Computing and Tuning Guide <https://github.com/RadeonOpenCompute/ROCm/blob/rocm-4.5.2/AMD%20Instinct%E2%84%A2High%20Performance%20Computing%20and%20Tuning%20Guide.pdf>`__
 
 
 
@@ -217,19 +217,19 @@ HIP Documentation Updates
 
 -  HIP Programming Guide
 
-   https://github.com/RadeonOpenCompute/ROCm/blob/master/AMD_HIP_Programming_Guide.pdf
+   https://github.com/RadeonOpenCompute/ROCm/blob/rocm-4.5.2/AMD_HIP_Programming_Guide.pdf
 
 -  HIP API Guide
 
-   https://github.com/RadeonOpenCompute/ROCm/blob/master/AMD-HIP-API-4.5.pdf
+   https://github.com/RadeonOpenCompute/ROCm/blob/rocm-4.5.2/AMD-HIP-API-4.5.pdf
 
 -  HIP-Supported CUDA API Reference Guide
 
-   https://github.com/RadeonOpenCompute/ROCm/blob/master/AMD_HIP_Supported_CUDA_API_Reference_Guide.pdf
+   https://github.com/RadeonOpenCompute/ROCm/blob/rocm-4.5.2/AMD_HIP_Supported_CUDA_API_Reference_Guide.pdf
 
 -  AMD ROCm Compiler Reference Guide
 
-   https://github.com/RadeonOpenCompute/ROCm/blob/master/AMD_Compiler_Reference_Guide_v4.5.pdf
+   https://github.com/RadeonOpenCompute/ROCm/blob/rocm-4.5.2/AMD_Compiler_Reference_Guide_v4.5.pdf
 
 -  HIP FAQ
 
@@ -249,11 +249,11 @@ AMD ROCm Data Center Tool
 
 - AMD ROCm Data Center Tool API Guide
 
-  https://github.com/RadeonOpenCompute/ROCm/blob/master/RDC_API_Manual_4.5.pdf
+  https://github.com/RadeonOpenCompute/ROCm/blob/rocm-4.5.2/RDC_API_Manual_4.5.pdf
   
 - AMD ROCm Data Center Tool User Guide
 
-  https://github.com/RadeonOpenCompute/ROCm/blob/master/AMD_ROCm_DataCenter_Tool_User_Guide_v4.5.pdf
+  https://github.com/RadeonOpenCompute/ROCm/blob/rocm-4.5.2/AMD_ROCm_DataCenter_Tool_User_Guide_v4.5.pdf
 
 
 ROCm SMI API Guide
@@ -261,7 +261,7 @@ ROCm SMI API Guide
 
 -  ROCm SMI API Guide
 
-   https://github.com/RadeonOpenCompute/ROCm/blob/master/ROCm_SMI_Manual_4.5.pdf
+   https://github.com/RadeonOpenCompute/ROCm/blob/rocm-4.5.2/ROCm_SMI_Manual_4.5.pdf
    
 
 ROC Debugger User and API Guide
@@ -269,11 +269,11 @@ ROC Debugger User and API Guide
 
 -  ROCDebugger User Guide
 
-   https://github.com/RadeonOpenCompute/ROCm/blob/master/ROCDebugger_User_Guide.pdf
+   https://github.com/RadeonOpenCompute/ROCm/blob/rocm-4.5.2/ROCDebugger_User_Guide.pdf
 
 -  Debugger API Guide
 
-   https://github.com/RadeonOpenCompute/ROCm/blob/master/ROCDebugger_API_Guide.pdf
+   https://github.com/RadeonOpenCompute/ROCm/blob/rocm-4.5.2/ROCDebugger_API_Guide.pdf
    
 
 OpenMP Documentation
@@ -341,7 +341,7 @@ Support for HIP Graph
 
 ROCm v4.5 extends support for HIP Graph. For details, refer to the HIP API Guide at,
 
-https://github.com/RadeonOpenCompute/ROCm/blob/master/AMD-HIP-API-4.5.pdf
+https://github.com/RadeonOpenCompute/ROCm/blob/rocm-4.5.2/AMD-HIP-API-4.5.pdf
 
 
 Enhanced *launch_bounds* Check Error Log Message
@@ -356,7 +356,7 @@ kernel. Besides, the kernel dim size and launch bounds values will also assist i
 
 For more details, refer to the HIP Programming Guide at
 
-https://github.com/RadeonOpenCompute/ROCm/blob/master/AMD_HIP_Programming_Guide.pdf
+https://github.com/RadeonOpenCompute/ROCm/blob/rocm-4.5.2/AMD_HIP_Programming_Guide.pdf
 
 
 HIP Runtime Compilation
@@ -370,7 +370,7 @@ files without spawning separate processes.
 
 For more details on hipRTC APIs, refer to the HIP API Guide at
 
-https://github.com/RadeonOpenCompute/ROCm/blob/master/AMD-HIP-API-4.5.pdf
+https://github.com/RadeonOpenCompute/ROCm/blob/rocm-4.5.2/AMD-HIP-API-4.5.pdf
 
 
 New Flag for Backwards Compatibility on float/double atomicAdd Function
@@ -396,7 +396,7 @@ compilers that do not support floating point atomics.
 
 For details on how to build the HIP runtime, refer to the HIP Programming Guide at
 
-https://github.com/RadeonOpenCompute/ROCm/blob/master/AMD_HIP_Programming_Guide.pdf
+https://github.com/RadeonOpenCompute/ROCm/blob/rocm-4.5.2/AMD_HIP_Programming_Guide.pdf
 
 
 
@@ -1017,7 +1017,7 @@ This issue is currently under investigation and will be fixed in a future releas
 
 For more information, refer to the ROCgdb User Guide at,
 
-https://github.com/RadeonOpenCompute/ROCm/blob/master/AMD_ROCDebugger_User_Guide.pdf
+https://github.com/RadeonOpenCompute/ROCm/blob/rocm-4.5.2/ROCDebugger_User_Guide.pdf
 
 
 clinfo and rocminfo Do Not Display Marketing Name

--- a/Programming_Guides/HIP-GUIDE.rst
+++ b/Programming_Guides/HIP-GUIDE.rst
@@ -23,13 +23,13 @@ Programming Guide (PDF)
 
 You can access and download the latest version of the HIP Programming Guide.  
 
-`Download PDF <https://github.com/RadeonOpenCompute/ROCm/blob/master/AMD_HIP_Programming_Guide.pdf>`__
+`Download PDF <https://github.com/RadeonOpenCompute/ROCm/blob/rocm-4.5.2/AMD_HIP_Programming_Guide.pdf>`__
 
 Or
 
 Access the following link for the online version of the guide,
 
-https://github.com/RadeonOpenCompute/ROCm/blob/master/AMD_HIP_Programming_Guide.pdf
+https://github.com/RadeonOpenCompute/ROCm/blob/rocm-4.5.2/AMD_HIP_Programming_Guide.pdf
 
 
 Related Topics
@@ -40,7 +40,7 @@ HIP API Guide
 
 You can access the Doxygen-generated HIP API Guide at the following location:
 
-https://github.com/RadeonOpenCompute/ROCm/blob/master/AMD-HIP-API-4.5.pdf
+https://github.com/RadeonOpenCompute/ROCm/blob/rocm-4.5.2/AMD-HIP-API-4.5.pdf
 
 
 HIP_Supported_CUDA_API_Reference_Guide
@@ -48,7 +48,7 @@ HIP_Supported_CUDA_API_Reference_Guide
 
 You can access and download the latest version of the HIP-Supported CUDA API Reference Guide.  
 
-https://github.com/RadeonOpenCompute/ROCm/blob/master/AMD_HIP_Supported_CUDA_API_Reference_Guide.pdf
+https://github.com/RadeonOpenCompute/ROCm/blob/rocm-4.5.2/AMD_HIP_Supported_CUDA_API_Reference_Guide.pdf
 
 
 AMD ROCm Compiler Reference Guide 
@@ -56,7 +56,7 @@ AMD ROCm Compiler Reference Guide
 
 You can access and download the AMD ROCm Compiler Reference Guide at,
 
-https://github.com/RadeonOpenCompute/ROCm/blob/master/AMD_Compiler_Reference_Guide_v4.5.pdf
+https://github.com/RadeonOpenCompute/ROCm/blob/rocm-4.5.2/AMD_Compiler_Reference_Guide_v4.5.pdf
 
 
 HIP Installation Instructions

--- a/Programming_Guides/HIP_API_Guide.rst
+++ b/Programming_Guides/HIP_API_Guide.rst
@@ -5,7 +5,7 @@ HIP API Documentation v4.5
 
 You can access the latest Doxygen-generated HIP API Guide at the following location:
 
-https://github.com/RadeonOpenCompute/ROCm/blob/master/AMD-HIP-API-4.5.pdf
+https://github.com/RadeonOpenCompute/ROCm/blob/rocm-4.5.2/AMD-HIP-API-4.5.pdf
 
 
 ============================================
@@ -14,7 +14,7 @@ HIP-Supported CUDA API Reference Guide v4.5
 
 You can access the latest Reference guide at,
 
-https://github.com/RadeonOpenCompute/ROCm/blob/master/AMD_HIP_Supported_CUDA_API_Reference_Guide.pdf
+https://github.com/RadeonOpenCompute/ROCm/blob/rocm-4.5.2/AMD_HIP_Supported_CUDA_API_Reference_Guide.pdf
 
 
 ========================================
@@ -23,13 +23,13 @@ AMD ROCm Compiler Reference Guide v4.5
 
 You can access and download the AMD ROCm Compiler Reference Guide at,
 
-https://github.com/RadeonOpenCompute/ROCm/blob/master/AMD_Compiler_Reference_Guide_v4.5.pdf
+https://github.com/RadeonOpenCompute/ROCm/blob/rocm-4.5.2/AMD_Compiler_Reference_Guide_v4.5.pdf
 
 
 Supported CUDA APIs 
 ---------------------
 
-https://github.com/RadeonOpenCompute/ROCm/blob/master/AMD_HIP_Supported_CUDA_API_Reference_Guide.pdf
+https://github.com/RadeonOpenCompute/ROCm/blob/rocm-4.5.2/AMD_HIP_Supported_CUDA_API_Reference_Guide.pdf
 
 To access the following supported CUDA APIs, see
 

--- a/Programming_Guides/Programming-Guides.rst
+++ b/Programming_Guides/Programming-Guides.rst
@@ -21,13 +21,13 @@ Programming Guide (PDF)
 
 You can access and download the latest version of the HIP Programming Guide.  
 
-`Download PDF <https://github.com/RadeonOpenCompute/ROCm/blob/master/AMD_HIP_Programming_Guide.pdf>`__
+`Download PDF <https://github.com/RadeonOpenCompute/ROCm/blob/rocm-4.5.2/AMD_HIP_Programming_Guide.pdf>`__
 
 or
 
 Access the following link for the guide,
 
-https://github.com/RadeonOpenCompute/ROCm/blob/master/AMD_HIP_Programming_Guide.pdf
+https://github.com/RadeonOpenCompute/ROCm/blob/rocm-4.5.2/AMD_HIP_Programming_Guide.pdf
 
 
 Related Topics
@@ -38,7 +38,7 @@ HIP API Guide
 
 You can access the Doxygen-generated HIP API Guide at the following location:
 
-https://github.com/RadeonOpenCompute/ROCm/blob/master/AMD-HIP-API-4.5.pdf
+https://github.com/RadeonOpenCompute/ROCm/blob/rocm-4.5.2/AMD-HIP-API-4.5.pdf
 
 
 HIP_Supported_CUDA_API_Reference_Guide
@@ -46,7 +46,7 @@ HIP_Supported_CUDA_API_Reference_Guide
 
 You can access and download the latest version of the HIP-Supported CUDA API Reference Guide.  
 
-https://github.com/RadeonOpenCompute/ROCm/blob/master/AMD_HIP_Supported_CUDA_API_Reference_Guide.pdf
+https://github.com/RadeonOpenCompute/ROCm/blob/rocm-4.5.2/AMD_HIP_Supported_CUDA_API_Reference_Guide.pdf
 
 
 AMD ROCm Compiler Reference Guide 
@@ -54,7 +54,7 @@ AMD ROCm Compiler Reference Guide
 
 You can access and download the AMD ROCm Compiler Reference Guide at,
 
-https://github.com/RadeonOpenCompute/ROCm/blob/master/AMD_Compiler_Reference_Guide_v4.5.pdf
+https://github.com/RadeonOpenCompute/ROCm/blob/rocm-4.5.2/AMD_Compiler_Reference_Guide_v4.5.pdf
 
 
 HIP Installation Instructions

--- a/ROCm_Tools/ROCm-Data-Center.rst
+++ b/ROCm_Tools/ROCm-Data-Center.rst
@@ -43,10 +43,10 @@ The audience for the AMD ROCm Data Center™ tool consists of:
 Download AMD ROCm Data Center Tool User Guide
 ==============================================
 
-https://github.com/RadeonOpenCompute/ROCm/blob/master/AMD_ROCm_DataCenter_Tool_User_Guide_v4.5.pdf  
+https://github.com/RadeonOpenCompute/ROCm/blob/rocm-4.5.2/AMD_ROCm_DataCenter_Tool_User_Guide_v4.5.pdf
 
 Download AMD ROCm Data Center Tool API Guide
 ==============================================
 
-https://github.com/RadeonOpenCompute/ROCm/blob/master/RDC_API_Manual_4.5.pdf
+https://github.com/RadeonOpenCompute/ROCm/blob/rocm-4.5.2/RDC_API_Manual_4.5.pdf
 


### PR DESCRIPTION
With the release of ROCm 5.0, the PDF manuals files for ROCm 4.5 have been deleted from the master branch of the ROCm GitHub repository. This deletion broke the links to the ROCm 4.5 manuals on rocmdocs.

We can fix the links by explicitly linking to the rocm-4.5.2 version of the ROCm GitHub repository.