### PR TITLE
Replacing all uses of apt-key with gpg

### DIFF
--- a/Archived_Documentation/4.2_Installation_Guide.rst
+++ b/Archived_Documentation/4.2_Installation_Guide.rst
@@ -250,18 +250,18 @@ For Debian-based systems like Ubuntu, configure the Debian ROCm repository as fo
 
     sudo apt install wget gnupg2
 
-    wget -q -O - https://repo.radeon.com/rocm/rocm.gpg.key | sudo apt-key add -
+    curl -fsSL https://repo.radeon.com/rocm/rocm.gpg.key | sudo gpg --dearmor -o /usr/share/keyrings/rocm-archive-keyring.gpg
 
-    echo 'deb [arch=amd64] https://repo.radeon.com/rocm/apt/debian/ ubuntu main' | sudo tee /etc/apt/sources.list.d/rocm.list
+    echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/rocm-archive-keyring.gpg] https://repo.radeon.com/rocm/apt/debian/ ubuntu main' | sudo tee /etc/apt/sources.list.d/rocm.list
 
 
 **Note**: For ROCm v4.1 and lower, use 'xenial main' as shown below
 
 ::
 
-	wget -q -O - https://repo.radeon.com/rocm/rocm.gpg.key | sudo apt-key add -
+	curl -fsSL https://repo.radeon.com/rocm/rocm.gpg.key | sudo gpg --dearmor -o /usr/share/keyrings/rocm-archive-keyring.gpg
 
-	echo 'deb [arch=amd64] https://repo.radeon.com/rocm/apt/4.1/ xenial main' | sudo tee /etc/apt/sources.list.d/rocm.list
+	echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/rocm-archive-keyring.gpg] https://repo.radeon.com/rocm/apt/4.1/ xenial main' | sudo tee /etc/apt/sources.list.d/rocm.list
 
 
 

--- a/Archived_Documentation/4_1_Installation_Guide.rst
+++ b/Archived_Documentation/4_1_Installation_Guide.rst
@@ -231,9 +231,9 @@ For Debian-based systems like Ubuntu, configure the Debian ROCm repository as fo
 
 ::
 
-    wget -q -O - https://repo.radeon.com/rocm/rocm.gpg.key | sudo apt-key add -
+    curl -fsSL https://repo.radeon.com/rocm/rocm.gpg.key | sudo gpg --dearmor -o /usr/share/keyrings/rocm-archive-keyring.gpg
 
-    echo 'deb [arch=amd64] https://repo.radeon.com/rocm/apt/4.1/ xenial main' | sudo tee /etc/apt/sources.list.d/rocm.list
+    echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/rocm-archive-keyring.gpg] https://repo.radeon.com/rocm/apt/4.1/ xenial main' | sudo tee /etc/apt/sources.list.d/rocm.list
 
 
 **Note**: For developer systems or Docker containers (where it could be beneficial to use a fixed ROCm version), select a versioned repository from: 

--- a/Deep_learning/Deep-learning.rst
+++ b/Deep_learning/Deep-learning.rst
@@ -975,8 +975,8 @@ MIVisionX provides developers with docker images for Ubuntu 16.04, Ubuntu 18.04,
 
 ::
 
-   wget -qO - https://repo.radeon.com/rocm/apt/debian/rocm.gpg.key | sudo apt-key add -
-   echo 'deb [arch=amd64] https://repo.radeon.com/rocm/apt/debian/ xenial main' | sudo tee /etc/apt/sources.list.d/rocm.list
+   curl -fsSL https://repo.radeon.com/rocm/rocm.gpg.key | sudo gpg --dearmor -o /usr/share/keyrings/rocm-archive-keyring.gpg
+   echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/rocm-archive-keyring.gpg] https://repo.radeon.com/rocm/apt/debian/ xenial main' | sudo tee /etc/apt/sources.list.d/rocm.list
    sudo apt update
    sudo apt install rocm-dkms
    sudo reboot
@@ -987,8 +987,8 @@ MIVisionX provides developers with docker images for Ubuntu 16.04, Ubuntu 18.04,
 ::
 
    sudo apt-get install curl
-   sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-   sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+   curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
+   echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
    sudo apt-get update
    apt-cache policy docker-ce
    sudo apt-get install -y docker-ce

--- a/Deep_learning/caffe.rst
+++ b/Deep_learning/caffe.rst
@@ -31,9 +31,9 @@ Installing ROCm Debian packages:
 
   PKG_REPO="http://repo.radeon.com/rocm/apt/debian/"
    
-  wget -qO - $PKG_REPO/rocm.gpg.key | sudo apt-key add -
+  curl -fsSL /rocm.gpg.key | sudo gpg --dearmor -o /usr/share/keyrings/rocm-archive-keyring.gpg
   
-  sudo sh -c "echo deb [arch=amd64] $PKG_REPO xenial main > /etc/apt/sources.list.d/rocm.list"
+  sudo sh -c "echo deb [arch=amd64 signed-by=/usr/share/keyrings/rocm-archive-keyring.gpg] $PKG_REPO xenial main > /etc/apt/sources.list.d/rocm.list"
  
   sudo apt-get update
   

--- a/GCN_ISA_Manuals/caffe.rst
+++ b/GCN_ISA_Manuals/caffe.rst
@@ -31,9 +31,9 @@ Installing ROCm Debian packages:
 
   PKG_REPO="http://repo.radeon.com/rocm/apt/debian/"
    
-  wget -qO - $PKG_REPO/rocm.gpg.key | sudo apt-key add -
+  curl -fsSL /rocm.gpg.key | sudo gpg --dearmor -o /usr/share/keyrings/rocm-archive-keyring.gpg
   
-  sudo sh -c "echo deb [arch=amd64] $PKG_REPO xenial main > /etc/apt/sources.list.d/rocm.list"
+  sudo sh -c "echo deb [arch=amd64 signed-by=/usr/share/keyrings/rocm-archive-keyring.gpg] $PKG_REPO xenial main > /etc/apt/sources.list.d/rocm.list"
  
   sudo apt-get update
   

--- a/Installation_Guide/Archive/v4.1-Installation-Guide
+++ b/Installation_Guide/Archive/v4.1-Installation-Guide
@@ -231,9 +231,9 @@ For Debian-based systems like Ubuntu, configure the Debian ROCm repository as fo
 
 ::
 
-    wget -q -O - https://repo.radeon.com/rocm/rocm.gpg.key | sudo apt-key add -
+    curl -fsSL https://repo.radeon.com/rocm/rocm.gpg.key | sudo gpg --dearmor -o /usr/share/keyrings/rocm-archive-keyring.gpg
 
-    echo 'deb [arch=amd64] https://repo.radeon.com/rocm/apt/4.1/ xenial main' | sudo tee /etc/apt/sources.list.d/rocm.list
+    echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/rocm-archive-keyring.gpg] https://repo.radeon.com/rocm/apt/4.1/ xenial main' | sudo tee /etc/apt/sources.list.d/rocm.list
 
 
 **Note**: For developer systems or Docker containers (where it could be beneficial to use a fixed ROCm version), select a versioned repository from: 

--- a/Installation_Guide/Archive/v4.2-Installation-Guide
+++ b/Installation_Guide/Archive/v4.2-Installation-Guide
@@ -225,9 +225,9 @@ For Debian-based systems like Ubuntu, configure the Debian ROCm repository as fo
 
 ::
 
-    wget -q -O - https://repo.radeon.com/rocm/rocm.gpg.key | sudo apt-key add -
+    curl -fsSL https://repo.radeon.com/rocm/rocm.gpg.key | sudo gpg --dearmor -o /usr/share/keyrings/rocm-archive-keyring.gpg
 
-    echo 'deb [arch=amd64] https://repo.radeon.com/rocm/apt/debian/ xenial main' | sudo tee /etc/apt/sources.list.d/rocm.list
+    echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/rocm-archive-keyring.gpg] https://repo.radeon.com/rocm/apt/debian/ xenial main' | sudo tee /etc/apt/sources.list.d/rocm.list
 
 
 **Note**: For developer systems or Docker containers (where it could be beneficial to use a fixed ROCm version), select a versioned repository from: 

--- a/Installation_Guide/Installation-Guide.rst
+++ b/Installation_Guide/Installation-Guide.rst
@@ -256,9 +256,9 @@ Key: https://repo.radeon.com/rocm/rocm.gpg.key
 	
 		sudo apt install wget gnupg2
 		
-		wget -q -O - https://repo.radeon.com/rocm/rocm.gpg.key | sudo apt-key add -
+		curl -fsSL https://repo.radeon.com/rocm/rocm.gpg.key | sudo gpg --dearmor -o /usr/share/keyrings/rocm-archive-keyring.gpg
 		
-		echo 'deb [arch=amd64] https://repo.radeon.com/rocm/apt/<ROCm_version#>/ ubuntu main' | sudo tee /etc/apt/sources.list.d/rocm.list
+		echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/rocm-archive-keyring.gpg] https://repo.radeon.com/rocm/apt/<ROCm_version#>/ ubuntu main' | sudo tee /etc/apt/sources.list.d/rocm.list
 
 
 For example
@@ -267,7 +267,7 @@ For the current version of ROCm, ensure you replace *<ROCm_version#>* with debia
 
 ::
 
-		echo 'deb [arch=amd64] https://repo.radeon.com/rocm/apt/debian/ ubuntu main' | sudo tee /etc/apt/sources.list.d/rocm.list
+		echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/rocm-archive-keyring.gpg] https://repo.radeon.com/rocm/apt/debian/ ubuntu main' | sudo tee /etc/apt/sources.list.d/rocm.list
 		
 
 For older versions of ROCm, replace *<ROCm_version#>* with any ROCm versions number like 4.3.1, 4.3 or 4.2.
@@ -276,21 +276,21 @@ For example,
 
 ::
 
-		echo 'deb [arch=amd64] https://repo.radeon.com/rocm/apt/4.3/ ubuntu main' | sudo tee /etc/apt/sources.list.d/rocm.list
+		echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/rocm-archive-keyring.gpg] https://repo.radeon.com/rocm/apt/4.3/ ubuntu main' | sudo tee /etc/apt/sources.list.d/rocm.list
 
 
 **Note**: For ROCm v4.1 and lower, use *‘xenial main’*, instead of 'ubuntu main', as shown below.
 
 ::
 
-		wget -q -O - https://repo.radeon.com/rocm/rocm.gpg.key | sudo apt-key add -
-		echo 'deb [arch=amd64] https://repo.radeon.com/rocm/apt/<ROCm_version#>/ xenial main' | sudo tee /etc/apt/sources.list.d/rocm.list
+		curl -fsSL https://repo.radeon.com/rocm/rocm.gpg.key | sudo gpg --dearmor -o /usr/share/keyrings/rocm-archive-keyring.gpg
+		echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/rocm-archive-keyring.gpg] https://repo.radeon.com/rocm/apt/<ROCm_version#>/ xenial main' | sudo tee /etc/apt/sources.list.d/rocm.list
 
 For example,
 
 ::
 
-		echo 'deb [arch=amd64] https://repo.radeon.com/rocm/apt/4.1/ ubuntu main' | sudo tee /etc/apt/sources.list.d/rocm.list
+		echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/rocm-archive-keyring.gpg] https://repo.radeon.com/rocm/apt/4.1/ ubuntu main' | sudo tee /etc/apt/sources.list.d/rocm.list
 
 
 
@@ -302,7 +302,7 @@ The gpg key may change; ensure it is updated when installing a new release. If t
 
 ::
 
-	wget -q -O - https://repo.radeon.com/rocm/rocm.gpg.key | sudo apt-key add -
+	curl -fsSL https://repo.radeon.com/rocm/rocm.gpg.key | sudo gpg --dearmor -o /usr/share/keyrings/rocm-archive-keyring.gpg
 
 
 The current rocm.gpg.key is not available in a standard key ring distribution, but has the following sha1sum hash:

--- a/Installation_Guide/Installation_new.rst
+++ b/Installation_Guide/Installation_new.rst
@@ -729,7 +729,7 @@ Add the gpg key for AMDGPU and ROCm repositories. For Debian-based systems like 
 ::
 
                              
-              $ wget -q -O - https://repo.radeon.com/rocm/rocm.gpg.key | sudo apt-key add -
+              $ curl -fsSL https://repo.radeon.com/rocm/rocm.gpg.key | sudo gpg --dearmor -o /usr/share/keyrings/rocm-archive-keyring.gpg
 
 
 **NOTE**: The gpg key may change. Ensure it is updated when installing a new release. If the key signature verification fails while updating, re-add the key from the ROCm apt repository as mentioned above. The current rocm.gpg.key is not available in a standard key ring distribution. However, it has the following sha1sum hash:
@@ -750,14 +750,14 @@ For <amdgpu baseurl>  in the command below, refer to the AMDGPU base URLs as doc
 
 ::
 
-               $ echo 'deb [arch=amd64] <amdgpu baseurl> bionic main' | sudo tee /etc/apt/sources.list.d/amdgpu.list
+               $ echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/rocm-archive-keyring.gpg] <amdgpu baseurl> bionic main' | sudo tee /etc/apt/sources.list.d/amdgpu.list
                
 
 **Ubuntu 20.04**
 
 ::
 
-               $ echo 'deb [arch=amd64] <amdgpu baseurl> focal main' | sudo tee /etc/apt/sources.list.d/amdgpu.list
+               $ echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/rocm-archive-keyring.gpg] <amdgpu baseurl> focal main' | sudo tee /etc/apt/sources.list.d/amdgpu.list
                
 
 
@@ -793,7 +793,7 @@ For <rocm baseurl> in the command below, refer to the ROCm base URLs as document
 
 ::
 
-               $ echo 'deb [arch=amd64] <rocm baseurl> ubuntu main' | sudo tee /etc/apt/sources.list.d/rocm.list
+               $ echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/rocm-archive-keyring.gpg] <rocm baseurl> ubuntu main' | sudo tee /etc/apt/sources.list.d/rocm.list
                
                $ sudo apt-get update
                

--- a/Installation_Guide/Quick Start Installation Guide.rst
+++ b/Installation_Guide/Quick Start Installation Guide.rst
@@ -63,9 +63,9 @@ For Debian-based systems like Ubuntu, configure the Debian ROCm repository as fo
 
 ::
 
-    wget -q -O - https://repo.radeon.com/rocm/apt/debian/rocm.gpg.key | sudo apt-key add -
+    curl -fsSL https://repo.radeon.com/rocm/rocm.gpg.key | sudo gpg --dearmor -o /usr/share/keyrings/rocm-archive-keyring.gpg
 
-    echo 'deb [arch=amd64] http://repo.radeon.com/rocm/apt/debian/ xenial main' | sudo tee /etc/apt/sources.list.d/rocm.list
+    echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/rocm-archive-keyring.gpg] http://repo.radeon.com/rocm/apt/debian/ xenial main' | sudo tee /etc/apt/sources.list.d/rocm.list
 
 
 The gpg key may change; ensure it is updated when installing a new release. If the key signature verification fails while updating, re-add the key from the ROCm apt repository.

--- a/Installation_Guide/ROCk-kernel.rst
+++ b/Installation_Guide/ROCk-kernel.rst
@@ -17,8 +17,8 @@ Installation steps:
 
 Install the ROCm compute firmware and rock-dkms kernel modules, **reboot required**
 ::
- wget -qO - https://repo.radeon.com/rocm/apt/debian/rocm.gpg.key | sudo apt-key add -
- echo deb [arch=amd64] http://repo.radeon.com/rocm/apt/debian/ xenial main | sudo tee /etc/apt/sources.list.d/rocm.list
+ curl -fsSL https://repo.radeon.com/rocm/rocm.gpg.key | sudo gpg --dearmor -o /usr/share/keyrings/rocm-archive-keyring.gpg
+ echo deb [arch=amd64 signed-by=/usr/share/keyrings/rocm-archive-keyring.gpg] http://repo.radeon.com/rocm/apt/debian/ xenial main | sudo tee /etc/apt/sources.list.d/rocm.list
  sudo apt-get update && sudo apt-get install compute-firmware rock-dkms
  sudo update-initramfs -u
  sudo reboot

--- a/Non-Doxygen_RST/deeplearning/Deep-learning.rst
+++ b/Non-Doxygen_RST/deeplearning/Deep-learning.rst
@@ -1009,8 +1009,8 @@ MIVisionX provides developers with docker images for Ubuntu 16.04, Ubuntu 18.04,
 
 ::
 
-   wget -qO - https://repo.radeon.com/rocm/apt/debian/rocm.gpg.key | sudo apt-key add -
-   echo 'deb [arch=amd64] https://repo.radeon.com/rocm/apt/debian/ xenial main' | sudo tee /etc/apt/sources.list.d/rocm.list
+   curl -fsSL https://repo.radeon.com/rocm/rocm.gpg.key | sudo gpg --dearmor -o /usr/share/keyrings/rocm-archive-keyring.gpg
+   echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/rocm-archive-keyring.gpg] https://repo.radeon.com/rocm/apt/debian/ xenial main' | sudo tee /etc/apt/sources.list.d/rocm.list
    sudo apt update
    sudo apt install rocm-dkms
    sudo reboot
@@ -1021,8 +1021,8 @@ MIVisionX provides developers with docker images for Ubuntu 16.04, Ubuntu 18.04,
 ::
 
    sudo apt-get install curl
-   sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-   sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+   curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
+   echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
    sudo apt-get update
    apt-cache policy docker-ce
    sudo apt-get install -y docker-ce

--- a/Programming_Guides/Opencl-programming-guide.rst
+++ b/Programming_Guides/Opencl-programming-guide.rst
@@ -1766,7 +1766,7 @@ Either install the tar archive, or install the .deb package.
 
 **Debian package :**
 
-1. Download the ``amdcodexl-*.deb 64-bit Linux Debian package.``
+1. Download the ``amdcodexl-*.deb [arch=amd64 signed-by=/usr/share/keyrings/rocm-archive-keyring.gpg]4-bit Linux Debian package.``
 
 2. Run: ``$ sudo dpkg -i amdcodexl_x.x.x-1_amd64.deb ``
    

--- a/ROCm_API_References/Thrust.rst
+++ b/ROCm_API_References/Thrust.rst
@@ -23,8 +23,8 @@ Installation
 ****************
 AMD ROCm Installation
 ::
- $ wget -qO - https://repo.radeon.com/rocm/apt/debian/rocm.gpg.key | sudo apt-key add -
- $ sudo sh -c 'echo deb [arch=amd64] http://repo.radeon.com/rocm/apt/debian/ xenial main > /etc/apt/sources.list.d/rocm.list'
+ $ curl -fsSL https://repo.radeon.com/rocm/rocm.gpg.key | sudo gpg --dearmor -o /usr/share/keyrings/rocm-archive-keyring.gpg
+ $ sudo sh -c 'echo deb [arch=amd64 signed-by=/usr/share/keyrings/rocm-archive-keyring.gpg] http://repo.radeon.com/rocm/apt/debian/ xenial main > /etc/apt/sources.list.d/rocm.list'
  $ sudo apt-get update
  $ sudo apt install rocm-dkms
  

--- a/ROCm_Libraries/dep-lib.rst
+++ b/ROCm_Libraries/dep-lib.rst
@@ -124,8 +124,8 @@ Refer `Here <http://rocm-documentation.readthedocs.io/en/latest/Installation_Gui
 
 Follow Steps to install rocm package
 ::
-  wget -qO - https://packages.amd.com/rocm/apt/debian/rocm.gpg.key | sudo apt-key add -
-  sudo sh -c 'echo deb [arch=amd64] https://packages.amd.com/rocm/apt/debian/ xenial main > /etc/apt/sources.list.d/rocm.list'
+  curl -fsSL https://repo.radeon.com/rocm/rocm.gpg.key | sudo gpg --dearmor -o /usr/share/keyrings/rocm-archive-keyring.gpg
+  sudo sh -c 'echo deb [arch=amd64 signed-by=/usr/share/keyrings/rocm-archive-keyring.gpg] https://packages.amd.com/rocm/apt/debian/ xenial main > /etc/apt/sources.list.d/rocm.list'
   sudo apt-get update
   sudo apt-get install rocm
 
@@ -292,8 +292,8 @@ For Debian based systems, like Ubuntu, configure the Debian ROCm repository as f
 
 ::
 
-  wget -qO - https://packages.amd.com/rocm/apt/debian/rocm.gpg.key | sudo apt-key add -
-  sudo sh -c 'echo deb [arch=amd64] http://packages.amd.com/rocm/apt/debian/ xenial main > /etc/apt/sources.list.d/rocm.list'
+  curl -fsSL https://repo.radeon.com/rocm/rocm.gpg.key | sudo gpg --dearmor -o /usr/share/keyrings/rocm-archive-keyring.gpg
+  sudo sh -c 'echo deb [arch=amd64 signed-by=/usr/share/keyrings/rocm-archive-keyring.gpg] http://packages.amd.com/rocm/apt/debian/ xenial main > /etc/apt/sources.list.d/rocm.list'
 
 The gpg key might change, so it may need to be updated when installing a new release.
 
@@ -1060,9 +1060,9 @@ Steps to install rocm package are,
 
 ::
 
-  wget -qO - http://packages.amd.com/rocm/apt/debian/rocm.gpg.key | sudo apt-key add -
+  curl -fsSL https://repo.radeon.com/rocm/rocm.gpg.key | sudo gpg --dearmor -o /usr/share/keyrings/rocm-archive-keyring.gpg
 
-  sudo sh -c 'echo deb [arch=amd64] http://packages.amd.com/rocm/apt/debian/ xenial main > /etc/apt/sources.list.d/rocm.list'
+  sudo sh -c 'echo deb [arch=amd64 signed-by=/usr/share/keyrings/rocm-archive-keyring.gpg] http://packages.amd.com/rocm/apt/debian/ xenial main > /etc/apt/sources.list.d/rocm.list'
 
   sudo apt-get update
 

--- a/Tutorial/caffe.rst
+++ b/Tutorial/caffe.rst
@@ -31,9 +31,9 @@ Installing ROCm Debian packages:
 
   PKG_REPO="http://repo.radeon.com/rocm/apt/debian/"
    
-  wget -qO - $PKG_REPO/rocm.gpg.key | sudo apt-key add -
+  curl -fsSL /rocm.gpg.key | sudo gpg --dearmor -o /usr/share/keyrings/rocm-archive-keyring.gpg
   
-  sudo sh -c "echo deb [arch=amd64] $PKG_REPO xenial main > /etc/apt/sources.list.d/rocm.list"
+  sudo sh -c "echo deb [arch=amd64 signed-by=/usr/share/keyrings/rocm-archive-keyring.gpg] $PKG_REPO xenial main > /etc/apt/sources.list.d/rocm.list"
  
   sudo apt-get update
   


### PR DESCRIPTION
Replacing all uses of apt-key with gpg, using Docker installation guide as an reference example. By doing this we acknowledge the [deprecation of apt-key utility](http://manpages.ubuntu.com/manpages/impish/man8/apt-key.8.html#:~:text=Use%20of%20apt%2Dkey%20is,packaged%20in%20gnupg)%20is%20required.) for this purpose:

> Use of apt-key is deprecated, except for the use of apt-key del in maintainer scripts to remove existing keys from the main keyring.