### PR TITLE
Remove dead link to ROCm installation page

### DIFF
--- a/Installation_Guide/Installation_new.rst
+++ b/Installation_Guide/Installation_new.rst
@@ -1,15 +1,6 @@
 .. image:: /Installation_Guide/amdblack.jpg
 
 
-============================
-ROCm Downloads Guide v5.0
-============================
-
-Use the following link for ROCm downloads,
-
-https://docs.amd.com/bundle/ROCm-Downloads-Guide-v5.0/page/ROCm_Installation.html
-
-
 ===============================
 ROCm Installation Guide v5.0
 ===============================


### PR DESCRIPTION
The top of the ROCm Downloads Guide currently has a dead link to the ROCm installation page - removing it